### PR TITLE
Clean up cmake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,28 +1,29 @@
 cmake_minimum_required(VERSION 3.3)
 
-project(docks)
-find_package(Qt5Widgets)
+project(KDDockWidgets)
+
+option(OPTION_DEVELOPER_MODE "Developer Mode" OFF)
+option(OPTION_ASAN_SUPPORT "Activate support for using ASAN" OFF)
 
 cmake_policy(SET CMP0020 NEW)
 cmake_policy(SET CMP0042 NEW)
+
+find_package(Qt5Widgets)
+set(CMAKE_AUTOMOC ON)
+
 set(ECM_MODULE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cmake/ECM/modules/")
 set(CMAKE_MODULE_PATH ${ECM_MODULE_DIR})
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-option(OPTION_DEVELOPER_MODE "Developer Mode" OFF)
-option(OPTION_ASAN_SUPPORT "Activate support for using ASAN" OFF)
-
-
 if (OPTION_ASAN_SUPPORT)
-   include(ECMEnableSanitizers)
+    include(ECMEnableSanitizers)
 endif()	
 
 if (OPTION_DEVELOPER_MODE)
-    add_definitions(-DDOCKS_DEVELOPER_MODE)
-    add_definitions(-DQT_FORCE_ASSERTS)
+    add_definitions(-DDOCKS_DEVELOPER_MODE -DQT_FORCE_ASSERTS)
     if (NOT MSVC)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror")
+        add_compile_options(-Wall -Wextra -Werror)
     endif()
 endif()
 
@@ -35,11 +36,10 @@ add_definitions(-DQT_NO_CAST_TO_ASCII
                 -DQT_NO_NARROWING_CONVERSIONS_IN_CONNECT
                 -DQT_STRICT_ITERATORS
                 -DQT_NO_KEYWORDS
+                -DQT_DISABLE_DEPRECATED_BEFORE=0x060000
+                -DQT_NO_FOREACH
                )
 
-add_definitions(-DQT_DISABLE_DEPRECATED_BEFORE=0x060000)
-set(CMAKE_AUTOMOC ON)
-add_definitions(-DQT_NO_FOREACH)
 add_subdirectory(src)
 
 if (OPTION_DEVELOPER_MODE)

--- a/examples/basic/CMakeLists.txt
+++ b/examples/basic/CMakeLists.txt
@@ -7,7 +7,6 @@ set(EXAMPLE_SRCS
 include_directories(${CMAKE_SOURCE_DIR}/src/)
 
 add_executable(docks_example ${EXAMPLE_SRCS})
-qt5_use_modules(docks_example Widgets)
-target_link_libraries(docks_example docks)
+target_link_libraries(docks_example docks Qt5::Widgets)
 install(TARGETS docks_example DESTINATION bin)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,35 +42,27 @@ else()
     set(IS_CLANG_BUILD FALSE)
 endif()
 
-if (CMAKE_COMPILER_IS_GNUCXX OR IS_CLANG_BUILD)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wshadow -Wconversion -fvisibility=hidden")
-
-    if (IS_CLANG_BUILD)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wweak-vtables")
-    endif()
-endif()
-
-
 set (DOCKS_INSTALLABLE_INCLUDES docks_export.h DockWidget.h MainWindow.h LayoutSaver.h Draggable_p.h KDDockWidgets.h)
 
 qt5_add_resources(RESOURCES ${CMAKE_CURRENT_SOURCE_DIR}/resources.qrc)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
+add_library(docks SHARED ${DOCKSLIBS_SRCS} ${DOCKS_INSTALLABLE_INCLUDES} ${RESOURCES})
+target_compile_definitions(docks PRIVATE BUILDING_DOCKS_LIBRARY)
+if (CMAKE_COMPILER_IS_GNUCXX OR IS_CLANG_BUILD)
+    target_compile_options(docks PRIVATE -Wshadow -Wconversion -fvisibility=hidden)
 
-add_definitions(-DBUILDING_DOCKS_LIBRARY)
-add_library(docks SHARED ${DOCKSLIBS_SRCS} ${RESOURCES})
-
-if (NOT WIN32)
-  find_package(Qt5X11Extras)
+    if (IS_CLANG_BUILD)
+        target_compile_options(docks PRIVATE -Wweak-vtables)
+    endif()
 endif()
 
-set(NEEDED_QT_MODULES Widgets)
-if (Qt5X11Extras_FOUND)
-  set(NEEDED_QT_MODULES ${NEEDED_QT_MODULES} X11Extras)
+target_link_libraries(docks Qt5::Widgets)
+if (NOT WIN32 AND NOT APPLE)
+    find_package(Qt5X11Extras)
+    target_link_libraries(docks Qt5::X11Extras)
 endif()
-
-qt5_use_modules(docks ${NEEDED_QT_MODULES} )
 
 install (TARGETS docks
          RUNTIME DESTINATION bin

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,14 +1,13 @@
-
 cmake_policy(SET CMP0043 NEW)
 
 include_directories(${CMAKE_SOURCE_DIR}/src)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
+find_package(Qt5Test)
+
 add_executable(tst_docks tst_docks.cpp utils.cpp)
-qt5_use_modules(tst_docks Widgets Test)
-target_link_libraries(tst_docks docks)
+target_link_libraries(tst_docks docks Qt5::Widgets Qt5::Test)
 
 ##### Fuzzer
 add_executable(fuzzer fuzzer.cpp utils.cpp)
-qt5_use_modules(fuzzer Widgets Test)
-target_link_libraries(fuzzer docks)
+target_link_libraries(fuzzer docks Qt5::Widgets Qt5::Test)
 


### PR DESCRIPTION
Use modern syntax in most places.

May consider:
- rename main target to kddockwidgets?
- using target definitions/compile options rather than the "global" values set in
  root project
- generate config file on install