### PR TITLE
Don't leak TabBarWidget's proxy style

### DIFF
--- a/src/private/widgets/TabBarWidget.cpp
+++ b/src/private/widgets/TabBarWidget.cpp
@@ -37,7 +37,10 @@ namespace KDDockWidgets {
 class MyProxy : public QProxyStyle
 {
 public:
-    MyProxy() : QProxyStyle(qApp->style()) {}
+    MyProxy() : QProxyStyle(qApp->style())
+    {
+        setParent(qApp);
+    }
 
     int styleHint(QStyle::StyleHint hint, const QStyleOption *option = nullptr,
                   const QWidget *widget = nullptr, QStyleHintReturn *returnData = nullptr) const override
@@ -63,12 +66,18 @@ public:
 
 using namespace KDDockWidgets;
 
+static MyProxy *proxyStyle()
+{
+    static auto *proxy = new MyProxy;
+    return proxy;
+}
+
 TabBarWidget::TabBarWidget(TabWidget *parent)
     : QTabBar(parent->asWidget())
     , TabBar(this, parent)
 {
     setMovable(Config::self().flags() & Config::Flag_AllowReorderTabs);
-    setStyle(new MyProxy());
+    setStyle(proxyStyle());
 }
 
 int TabBarWidget::numDockWidgets() const


### PR DESCRIPTION
Fixes leak reported by LSAN:

```
    #0 0x7f7b5687e968 in operator new(unsigned long) /build/gcc/src/gcc/libsanitizer/asan/asan_new_delete.cc:104
    #1 0x7f7b2e5b1096 in KDDockWidgets::TabBarWidget::TabBarWidget(KDDockWidgets::TabWidget*) ../3rdParty/kddockwidgets/src/private/widgets/TabBarWidget.cpp:71
    #2 0x7f7b2e295ba4 in KDDockWidgets::DefaultWidgetFactory::createTabBar(KDDockWidgets::TabWidget*) const ../3rdParty/kddockwidgets/src/FrameworkWidgetFactory.cpp:71
    #3 0x7f7b2e5b8f54 in KDDockWidgets::TabWidgetWidget::TabWidgetWidget(KDDockWidgets::Frame*) ../3rdParty/kddockwidgets/src/private/widgets/TabWidgetWidget.cpp:38
```

The owernship rules for QProxyStyle <-> QStyle are pure madness.
We do not want to delete the proxy we use as a base. And we must
not ever create multiple proxy styles for the same style either.
So add a static singleton for the proxy style and set its parent
to the qApp. This seems to work fine, at least the leak is gone
and we also don't get a crash at shutdown...