### PR TITLE
Fix build error under Qt 5.9.8-msvc2013

### DIFF
--- a/src/private/multisplitter/Item.cpp
+++ b/src/private/multisplitter/Item.cpp
@@ -3339,7 +3339,7 @@ void ItemContainer::fillFromVariantMap(const QVariantMap &map,
 
     for (const QVariant &childV : childrenV) {
         const QVariantMap childMap = childV.toMap();
-        const bool isContainer = childMap[QStringLiteral("isContainer")].toBool();
+        const bool isContainer = childMap.value(QStringLiteral("isContainer")).toBool();
         Item *child = isContainer ? new ItemContainer(hostWidget(), this)
                                   : new Item(hostWidget(), this);
         child->fillFromVariantMap(childMap, widgets);


### PR DESCRIPTION
Make the compiler happy just like that compile under Linux.

This error message is
D:\Projects\qt\KDDockWidgets\src\private\multisplitter\Item.cpp(3342): 
error C2958: the left bracket '[' found at 'd:\projects\qt\kddockwidgets\src\private\multisplitter\item.cpp(3342)' was not matched correctly