### PR TITLE
Frame: stop using "virtual" signals

### DIFF
--- a/src/FocusScope.cpp
+++ b/src/FocusScope.cpp
@@ -109,7 +109,7 @@ void FocusScope::Private::setIsFocused(bool is)
             emitDockWidgetFocusChanged();
 
         if (!m_inCtor) // Hack so we don't call pure-virtual
-            Q_EMIT q->isFocusedChanged();
+            /* Q_EMIT */ q->isFocusedChangedCallback();
     }
 }
 
@@ -125,7 +125,7 @@ void FocusScope::Private::onFocusObjectChanged(QObject *obj)
     if (is && m_lastFocusedInScope != widget && !qobject_cast<TitleBar*>(obj)) {
         m_lastFocusedInScope = widget;
         setIsFocused(is);
-        Q_EMIT q->focusedWidgetChanged();
+        /* Q_EMIT */ q->focusedWidgetChangedCallback();
     } else {
         setIsFocused(is);
     }

--- a/src/FocusScope.h
+++ b/src/FocusScope.h
@@ -48,9 +48,10 @@ public:
     void focus(Qt::FocusReason = Qt::OtherFocusReason);
 
 /*Q_SIGNALS:*/
+protected:
     ///@brief reimplement in the 1st QObject derived class
-    virtual void isFocusedChanged() = 0;
-    virtual void focusedWidgetChanged() = 0;
+    virtual void isFocusedChangedCallback() = 0;
+    virtual void focusedWidgetChangedCallback() = 0;
 
 private:
     class Private;

--- a/src/private/Frame.cpp
+++ b/src/private/Frame.cpp
@@ -285,6 +285,16 @@ void Frame::onCurrentTabChanged(int index)
     }
 }
 
+void Frame::isFocusedChangedCallback()
+{
+    Q_EMIT isFocusedChanged();
+}
+
+void Frame::focusedWidgetChangedCallback()
+{
+    Q_EMIT focusedWidgetChanged();
+}
+
 void Frame::updateTitleBarVisibility()
 {
     if (m_updatingTitleBar || m_beingDeleted) {

--- a/src/private/Frame_p.h
+++ b/src/private/Frame_p.h
@@ -245,14 +245,17 @@ Q_SIGNALS:
     void hasTabsVisibleChanged();
     void layoutInvalidated();
     void isInMainWindowChanged();
-    void isFocusedChanged() override; // override from non-QObject
-    void focusedWidgetChanged() override;
+    void isFocusedChanged();
+    void focusedWidgetChanged();
 
 protected Q_SLOTS:
     void onDockWidgetCountChanged();
     void onCurrentTabChanged(int index);
 
 protected:
+    void isFocusedChangedCallback() final;
+    void focusedWidgetChangedCallback() final;
+
     virtual void renameTab(int index, const QString &) = 0;
 
     /**


### PR DESCRIPTION
They don't work as expected across DLL boundaries on MSVC: connecting
to Frame::isFocusedChanged using the PMF syntax fails.

The reason has to do with how MSVC implements pointers to virtual
function members: they are "regular" function pointers to a DLL-local
stub that implements the virtual call. For that reason, a connect()
happening in client code would generate a pointer for the signal that
doesn't compare equal to the same pointer generated from inside KDDW;
and moc-generated code relies on this comparison to find the index of
the signal.

Just avoid the whole thing: rename the non-signal virtual call into a
"callback", and reimplement it in the first QObject subclass to turn it
into a proper signal.