### PR TITLE
Fix issues with pri file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,12 +156,19 @@ macro(set_compiler_flags targetName)
 
 endmacro()
 
+set(${PROJECT_NAME}_DEPS "widgets")
+
 if(${PROJECT_NAME}_QTQUICK)
   find_package(Qt${QT_MAJOR_VERSION}Quick)
   find_package(Qt${QT_MAJOR_VERSION}QuickControls2)
   add_definitions(-DKDDOCKWIDGETS_QTQUICK)
+  set(${PROJECT_NAME}_DEPS "${${PROJECT_NAME}_DEPS} quick quickcontrols2")
 else()
   add_definitions(-DKDDOCKWIDGETS_QTWIDGETS)
+endif()
+
+if(NOT WIN32 AND NOT APPLE AND NOT EMSCRIPTEN AND NOT ${PROJECT_NAME}_QT6)
+  set(${PROJECT_NAME}_DEPS "${${PROJECT_NAME}_DEPS} x11extras")
 endif()
 
 if(${PROJECT_NAME}_STATIC)
@@ -178,22 +185,24 @@ if(USE_DEFAULT_INSTALL_LOCATION)
   endif()
 endif()
 
+add_subdirectory(src)
+if(${PROJECT_NAME}_PYTHON_BINDINGS)
+  add_subdirectory(python)
+endif()
+
 # Generate .pri file for qmake users
 include(ECMGeneratePriFile)
 set(PROJECT_VERSION_STRING ${${PROJECT_NAME}_VERSION})
 ecm_generate_pri_file(BASE_NAME KDDockWidgets
   LIB_NAME kddockwidgets
+  DEPS ${${PROJECT_NAME}_DEPS}
   FILENAME_VAR pri_filename
+  INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR}
 )
 install(FILES ${pri_filename} DESTINATION ${ECM_MKSPECS_INSTALL_DIR})
 
 install(FILES LICENSE.txt README.md DESTINATION ${INSTALL_DOC_DIR})
 install(DIRECTORY LICENSES DESTINATION ${INSTALL_DOC_DIR})
-
-add_subdirectory(src)
-if(${PROJECT_NAME}_PYTHON_BINDINGS)
-  add_subdirectory(python)
-endif()
 
 if(${PROJECT_NAME}_EXAMPLES)
   if (${PROJECT_NAME}_QTQUICK)

--- a/cmake/ECM/modules/ECMGeneratePriFile.cmake
+++ b/cmake/ECM/modules/ECMGeneratePriFile.cmake
@@ -160,7 +160,6 @@ function(ECM_GENERATE_PRI_FILE)
   else()
       set(PRI_TARGET_LIBS "${BASEPATH}/${EGPF_LIB_INSTALL_DIR}")
   endif()
-  set(PRI_TARGET_DEFINES "")
 
   set(PRI_FILENAME ${CMAKE_CURRENT_BINARY_DIR}/qt_${PRI_TARGET_BASENAME}.pri)
   if (EGPF_FILENAME_VAR)
@@ -168,6 +167,8 @@ function(ECM_GENERATE_PRI_FILE)
   endif()
 
   set(PRI_TARGET_MODULE_CONFIG "")
+  set(PRI_TARGET_DEFINES "")
+  set(PRI_TARGET_POSTFIX "")
   # backward compat: it was not obvious LIB_NAME needs to be a target name,
   # and some projects where the target name was not the actual library output name
   # passed the output name for LIB_NAME, so .name & .module prperties are correctly set.
@@ -177,6 +178,10 @@ function(ECM_GENERATE_PRI_FILE)
     if (target_type STREQUAL "STATIC_LIBRARY")
         set(PRI_TARGET_MODULE_CONFIG "staticlib")
     endif()
+    get_target_property(target_defs ${EGPF_LIB_NAME} INTERFACE_COMPILE_DEFINITIONS)
+    list(FILTER target_defs EXCLUDE REGEX ^QT_)
+    string(JOIN " " PRI_TARGET_DEFINES "${target_defs}")
+    set(PRI_TARGET_POSTFIX "$<TARGET_PROPERTY:${EGPF_LIB_NAME},$<UPPER_CASE:$<CONFIG>$<$<CONFIG:>:Debug>>_POSTFIX>")
   endif()
 
   file(GENERATE
@@ -187,8 +192,8 @@ QT.${PRI_TARGET_BASENAME}.MAJOR_VERSION = ${PROJECT_VERSION_MAJOR}
 QT.${PRI_TARGET_BASENAME}.MINOR_VERSION = ${PROJECT_VERSION_MINOR}
 QT.${PRI_TARGET_BASENAME}.PATCH_VERSION = ${PROJECT_VERSION_PATCH}
 QT.${PRI_TARGET_BASENAME}.name = ${PRI_TARGET_LIBNAME}
-QT.${PRI_TARGET_BASENAME}.module = ${PRI_TARGET_LIBNAME}
-QT.${PRI_TARGET_BASENAME}.defines = ${PRI_TARGET_DEFINES}
+QT.${PRI_TARGET_BASENAME}.module = ${PRI_TARGET_LIBNAME}${PRI_TARGET_POSTFIX}
+QT.${PRI_TARGET_BASENAME}.DEFINES = ${PRI_TARGET_DEFINES}
 QT.${PRI_TARGET_BASENAME}.includes = ${PRI_TARGET_INCLUDES}
 QT.${PRI_TARGET_BASENAME}.private_includes =
 QT.${PRI_TARGET_BASENAME}.libs = ${PRI_TARGET_LIBS}


### PR DESCRIPTION
The generated pri file has a few issues:
1. module is missing library postfix
2. defines is wrong case and always empty
3. includes refers to `include/KDDockWidgets`
4. depends is always empty
5. module_config is always empty
---
To elaborate on how each issue was fixed:
1. Use a generator expression to output the correct postfix corresponding to the current build type.
2. Capitalize the key and fill the value with entries from the `INTERFACE_COMPILE_DEFINITIONS` property.
3. This isn't very helpful on a case-sensitive filesystem.  Since all of the examples do `#include <kddockwidgets/FILE.h>` I set `INCLUDE_INSTALL_DIR` to just `${CMAKE_INSTALL_INCLUDEDIR}` which by default expands to `include` to support that use-case.
4. Fill `${PROJECT_NAME}_DEPS` with the correct list of dependencies according to the configuration settings and pass it along.
5. Detection of a static build was ostensibly already supported by EGPF, but the property that it checks for isn't set yet at the location where it is called, so the call needs to be moved down past `add_subdirectory(src)`.
---
Tested by building a project using the pri file on ubuntu for linux64, win32, and win64.