### PR TITLE
Handle tab icon updates.

### DIFF
--- a/src/private/Frame.cpp
+++ b/src/private/Frame.cpp
@@ -105,8 +105,11 @@ void Frame::onDockWidgetTitleChanged()
     updateTitleAndIcon();
 
     if (!m_inCtor) { // don't call pure virtual in ctor
-        if (auto dw = qobject_cast<DockWidgetBase*>(sender()))
-            renameTab(indexOfDockWidget(dw), dw->title());
+        if (auto dw = qobject_cast<DockWidgetBase*>(sender())) {
+            int index = indexOfDockWidget(dw);
+            renameTab(index, dw->title());
+            changeTabIcon(index, dw->icon(DockWidgetBase::IconPlace::TabBar));
+        }
     }
 }
 

--- a/src/private/Frame_p.h
+++ b/src/private/Frame_p.h
@@ -258,6 +258,7 @@ protected Q_SLOTS:
 
 protected:
     virtual void renameTab(int index, const QString &) = 0;
+    virtual void changeTabIcon(int index, const QIcon &) = 0;
 
     /**
      * @brief Returns the minimum size of the dock widgets.

--- a/src/private/TabWidget_p.h
+++ b/src/private/TabWidget_p.h
@@ -127,6 +127,9 @@ public:
     ///@brief rename's the tab's text
     virtual void renameTab(int index, const QString &) = 0;
 
+    ///@brief change the tab's icon
+    virtual void changeTabIcon(int index, const QIcon &) = 0;
+
     /**
      * @brief Returns the current index
      */

--- a/src/private/widgets/FrameWidget.cpp
+++ b/src/private/widgets/FrameWidget.cpp
@@ -169,6 +169,10 @@ void FrameWidget::renameTab(int index, const QString &text)
     m_tabWidget->renameTab(index, text);
 }
 
+void FrameWidget::changeTabIcon(int index, const QIcon &icon)
+{
+    m_tabWidget->changeTabIcon(index, icon);
+}
 
 int KDDockWidgets::FrameWidget::nonContentsHeight() const
 {

--- a/src/private/widgets/FrameWidget_p.h
+++ b/src/private/widgets/FrameWidget_p.h
@@ -49,6 +49,7 @@ protected:
     DockWidgetBase *dockWidgetAt_impl(int index) const override;
     QRect dragRect() const override;
     void renameTab(int index, const QString &) override;
+    void changeTabIcon(int index, const QIcon &) override;
     int nonContentsHeight() const override;
 private:
     friend class ::TestDocks;

--- a/src/private/widgets/TabWidgetWidget.cpp
+++ b/src/private/widgets/TabWidgetWidget.cpp
@@ -135,6 +135,11 @@ void TabWidgetWidget::renameTab(int index, const QString &text)
     setTabText(index, text);
 }
 
+void TabWidgetWidget::changeTabIcon(int index, const QIcon &icon)
+{
+    setTabIcon(index, icon);
+}
+
 DockWidgetBase *TabWidgetWidget::dockwidgetAt(int index) const
 {
     return qobject_cast<DockWidgetBase *>(widget(index));

--- a/src/private/widgets/TabWidgetWidget_p.h
+++ b/src/private/widgets/TabWidgetWidget_p.h
@@ -55,6 +55,7 @@ protected:
     bool insertDockWidget(int index, DockWidgetBase *, const QIcon&, const QString &title) override;
     void setTabBarAutoHide(bool) override;
     void renameTab(int index, const QString &) override;
+    void changeTabIcon(int index, const QIcon &) override;
 
     DockWidgetBase *dockwidgetAt(int index) const override;
     int currentIndex() const override;


### PR DESCRIPTION
Currently, calling `dock->setIcon(icon, DockWidgetBase::IconPlace::TabBar);` does not update the icon if the dock is already tabbed, and only appears if the dock is removed and re-added to a tab group.