### PR TITLE
Implemented the method for adjusting the position of a dragged item

### DIFF
--- a/src/private/DragController.cpp
+++ b/src/private/DragController.cpp
@@ -188,7 +188,7 @@ bool StateNone::handleMouseButtonPress(Draggable *draggable, QPoint globalPos, Q
     q->m_draggable = draggable;
     q->m_draggableGuard = draggable->asWidget();
     q->m_pressPos = globalPos;
-    q->m_offset = pos;
+    q->m_offset = draggable->mapToWindow(pos);
     Q_EMIT q->mousePressed();
     return false;
 }

--- a/src/private/Draggable_p.h
+++ b/src/private/Draggable_p.h
@@ -85,6 +85,14 @@ public:
      * If true, means the drag will simply move the existing window, and no undocking/untabbing is involved.
      */
     virtual bool isWindow() const = 0;
+
+    /**
+     * @brief Maps the given point in draggable mouse area`s coordinate system to
+     * the equivalent point in window's coordinate system,
+     * and returns the mapped coordinate.
+     */
+    virtual QPoint mapToWindow(const QPoint& pos) const { return pos; }
+
 private:
     class Private;
     Private *const d;


### PR DESCRIPTION
I want to implement a custom grip button, but shaking appears when I start dragging the window by this button. The DragController's offset is set only by the local coordinates of the dragged mouse area. And when I start dragging, setting the position of the window is wrong.

For example, I want to make a grip button directly on the dock widget. The red rectangle is where the position will move when dragging.
![image](https://user-images.githubusercontent.com/10116828/116066013-e18f6900-a687-11eb-8ab7-1270cb6d2824.png)

How do I solve this problem with a new method:
```
QPoint ToolBarGripModel::mapToWindow(const QPoint &pos) const
{
    QPointF result = m_gripMouseArea->mapToItem(m_toolbarWidget, QPointF(pos));
    if (m_toolbarWidget->titleBar()->isVisible()) {
        result.setY(result.y() + m_toolbarWidget->titleBar()->height());
    }

    return QPoint(result.x(), result.y());
}
```

```
bool StateNone::handleMouseButtonPress(Draggable *draggable, QPoint globalPos, QPoint pos)
{
    ...
    q->m_offset = draggable->mapToWindow(pos);
    ...
}
```
