### PR TITLE
Fixed closing of docks that are united in tabs

### DIFF
--- a/src/DockWidgetBase.cpp
+++ b/src/DockWidgetBase.cpp
@@ -642,6 +642,8 @@ void DockWidgetBase::Private::close()
     // Do some cleaning. Widget is hidden, but we must hide the tab containing it.
     if (Frame *frame = this->frame()) {
         frame->removeWidget(q);
+
+        q->setVisible(false);
         q->setParent(nullptr);
 
         if (SideBar *sb = DockRegistry::self()->sideBarForDockWidget(q)) {


### PR DESCRIPTION
Hello! I'm trying to close docks that are united in tabs. But several docks stay opened after using forceClose (or anything else for closing docks like `_kddwDockRegistry.clear()`)

<details>
<summary>Example for reproducing the issue</summary>

```qml
import QtQuick 2.6
import QtQuick.Controls 2.12
import QtQuick.Layouts 1.12

import com.kdab.dockwidgets 1.0 as KDDW

ApplicationWindow {
    id: root

    visible: true
    width: 1000
    height: 800

    ColumnLayout {
        anchors.fill: parent

        Button {
            Layout.alignment: Qt.AlignHCenter

            text: "close all docks"

            onClicked: {
                _kddwDockRegistry.clear()
            }
        }

        KDDW.MainWindowLayout {
            id: dockWidgetArea

            Layout.fillWidth: true
            Layout.fillHeight: true

            uniqueName: "MyWindowName-1"

            KDDW.DockWidget {
                id: dock1

                uniqueName: "dock1"

                Rectangle {
                    color: "red"
                }
            }

            KDDW.DockWidget {
                id: dock2

                uniqueName: "dock2"

                Rectangle {
                    color: "green"
                }
            }

            KDDW.DockWidget {
                id: dock3

                uniqueName: "dock3"

                Rectangle {
                    color: "blue"
                }
            }

            Component.onCompleted: {
                addDockWidget(dock1, KDDW.KDDockWidgets.Location_OnLeft)
                addDockWidget(dock2, KDDW.KDDockWidgets.Location_OnLeft)
                addDockWidget(dock3, KDDW.KDDockWidgets.Location_OnLeft)

                dock2.addDockWidgetAsTab(dock1.dockWidget)
                dock2.addDockWidgetAsTab(dock3.dockWidget)
            }
        }
    }
}

```
</details>

I have debugged DockWidgetBase::Private::close() and noticed that already closed docs will be reopened after changing their parent:

`
q->setParent(nullptr);
`

The closing works fine if hide docks before resetting their parents. If you don't like this fix, please, give me feedback. Thanks!

