### PR TITLE
Restoring geometry on quick

### DIFF
--- a/src/private/quick/QWidgetAdapter_quick.cpp
+++ b/src/private/quick/QWidgetAdapter_quick.cpp
@@ -308,6 +308,13 @@ void QWidgetAdapter::setFixedWidth(int width)
 
 void QWidgetAdapter::setGeometry(QRect rect)
 {
+    if (isTopLevel()) {
+        if (QWindow *w = windowHandle()) {
+            w->setGeometry(rect.x(), rect.y(), rect.width(), rect.height());
+            return;
+        }
+    }
+
     setWidth(rect.width());
     setHeight(rect.height());
     move(rect.topLeft());
@@ -380,16 +387,7 @@ void QWidgetAdapter::resize(int w, int h)
 
 bool QWidgetAdapter::isWindow() const
 {
-    QQuickItem *parent = parentItem();
-    if (!parent)
-        return true;
-
-    if (QQuickView *w = quickView()) {
-        if (parent == w->contentItem() || parent == w->rootObject())
-            return true;
-    }
-
-    return false;
+    return parentWidget(false) == nullptr;
 }
 
 bool QWidgetAdapter::isMaximized() const


### PR DESCRIPTION
The bug is reproduced on kddockwidgets_example_quick

To Reproduce
1. Save layout using the menu
2. Move the window to another location
3. Resize the window
4. Restore layout using the menu

Result - the window does not restore its position and size

The main mistake is that there is no check for the top level when setting the geometry
Another problem is the incorrect definition of the top level
The "MyWindowName-1" on kddockwidgets_example_quick is not top level. It is a mistake in my opinion