### PR TITLE
Corrected the detection of cursor movement over the window

### DIFF
--- a/src/MainWindowBase.cpp
+++ b/src/MainWindowBase.cpp
@@ -713,11 +713,6 @@ LayoutSaver::MainWindow MainWindowBase::serialize() const
 
 QRect MainWindowBase::windowGeometry() const
 {
-    // Returns the window geometry. This is usually the same as MainWindowBase::geometry()
-    // But fixes the following special cases:
-    // - QWidgets: Our MainWindow is embedded in another widget
-    // - QtQuick: Our MainWindow is QQuickItem
-    // Im both cases, what we want is the geometry of the QWindow, for save/restore purposes.
     if (QWindow *window = windowHandle())
         return window->geometry();
 

--- a/src/MainWindowBase.h
+++ b/src/MainWindowBase.h
@@ -200,6 +200,13 @@ public:
     /// if all dock widgets were closed (0 or more)
     Q_INVOKABLE bool closeDockWidgets(bool force = false);
 
+    /// @brief Returns the window geometry
+    /// This is usually the same as MainWindowBase::geometry()
+    /// But fixes the following special cases:
+    /// - QWidgets: Our MainWindow is embedded in another widget
+    /// - QtQuick: Our MainWindow is QQuickItem
+    QRect windowGeometry() const;
+
 protected:
     void setUniqueName(const QString &uniqueName);
     void onResized(QResizeEvent *); // Because QtQuick doesn't have resizeEvent()
@@ -223,7 +230,6 @@ private:
     friend class LayoutSaver;
     bool deserialize(const LayoutSaver::MainWindow &);
     LayoutSaver::MainWindow serialize() const;
-    QRect windowGeometry() const;
 };
 }
 

--- a/src/private/DragController.cpp
+++ b/src/private/DragController.cpp
@@ -787,6 +787,19 @@ static QWidgetOrQuick *qtTopLevelForHWND(HWND hwnd)
     return nullptr;
 }
 #endif
+
+static QRect topLevelGeometry(const QWidgetOrQuick* topLevel)
+{
+    QRect windowRect;
+    if (auto floatingWindow = dynamic_cast<const FloatingWindow*>(topLevel))
+        windowRect = floatingWindow->geometry();
+
+    if (auto mainWindow = dynamic_cast<const MainWindowBase*>(topLevel))
+        windowRect = mainWindow->windowGeometry();
+
+    return windowRect;
+}
+
 template <typename T>
 static WidgetType* qtTopLevelUnderCursor_impl(QPoint globalPos, const QVector<QWindow*> &windows, T windowBeingDragged)
 {
@@ -832,7 +845,9 @@ WidgetType *DragController::qtTopLevelUnderCursor() const
                 continue;
 
             if (auto tl = qtTopLevelForHWND(hwnd)) {
-                if (tl->geometry().contains(globalPos) && tl->objectName() != QStringLiteral("_docks_IndicatorWindow_Overlay")) {
+                QRect windowRect = topLevelGeometry(tl);
+
+                if (windowRect.contains(globalPos) && tl->objectName() != QStringLiteral("_docks_IndicatorWindow_Overlay")) {
                     qCDebug(toplevels) << Q_FUNC_INFO << "Found top-level" << tl;
                     return tl;
                 }


### PR DESCRIPTION
The bug is reproduced on kddockwidgets_example_quick. Windows 10

If you move the dock over the main window, dropArea won't work in some area. But if you maximize the window, then everything works as expected.

Before

https://user-images.githubusercontent.com/10116828/118609294-e218ac80-b7ba-11eb-9227-c7750de8838b.mp4

After

https://user-images.githubusercontent.com/10116828/118619223-abe02a80-b7c4-11eb-9fb2-e4c4d5df87be.mp4