### PR TITLE
Fixed a crash in MouseEventRedirector

### DIFF
--- a/src/private/quick/QWidgetAdapter_quick.cpp
+++ b/src/private/quick/QWidgetAdapter_quick.cpp
@@ -53,7 +53,8 @@ public:
 
 
         // Each source can only have one MouseEventRedirector
-        delete s_mouseEventRedirectors.value(eventSource);
+        auto oldRedirector = s_mouseEventRedirectors.take(eventSource);
+        oldRedirector->deleteLater();
 
         s_mouseEventRedirectors.insert(eventSource, this);
     }


### PR DESCRIPTION
**Description**

We have custom Frame.qml and FloatingWindow.qml in our application. Also, we want to have custom logic for showing/hiding the title bar for docks. There are 2 different title bars by default in the framework: one in Frame.qml and another in FloatingWindow.qml. But it is very hard to propagate this logic to both title bars. So, we have left only one title bar in our Frame.qml. But after that, we have found a crash in MouseEventRedirector::eventFilter.

**Environment**

macOS Big Sur, Qt: 5.15.2

**Steps for reproducing**

Replace the default Frame.qml with this content:
https://pastebin.com/7C6y0Tf1

And FloatingWindow.qml with this:
https://pastebin.com/Xqh953VY

(I have added comments to the main changes in those files)

After that, you should dock/undock any widgets (see the video for details). Please, notice that this isn't a stable reproduced issue

https://user-images.githubusercontent.com/67867444/118821261-5c2e5b80-b8b7-11eb-98db-7f823ce8cb6c.mp4

You'll get the crash after those changes in any examples (I have reproduced it on example_quick).  