### PR TITLE
Fixed removing filter right after it was added

### DIFF
--- a/src/private/quick/QWidgetAdapter_quick.cpp
+++ b/src/private/quick/QWidgetAdapter_quick.cpp
@@ -54,7 +54,7 @@ public:
         // Each source can only have one MouseEventRedirector
         auto oldRedirector = s_mouseEventRedirectors.take(eventSource);
         if (oldRedirector) {
-            eventSource->removeEventFilter(this);
+            eventSource->removeEventFilter(oldRedirector);
             oldRedirector->deleteLater();
         }
 


### PR DESCRIPTION
The filter will be removed right after it was added (see line 52). In our application, it leads to the inability to move any dock using the title bar