### PR TITLE
Fixed toggling dock widgets

### DIFF
--- a/src/DockWidgetBase.cpp
+++ b/src/DockWidgetBase.cpp
@@ -641,8 +641,8 @@ void DockWidgetBase::Private::close()
 
     // Do some cleaning. Widget is hidden, but we must hide the tab containing it.
     if (Frame *frame = this->frame()) {
-        frame->removeWidget(q);
         q->setParent(nullptr);
+        frame->removeWidget(q);
 
         if (SideBar *sb = DockRegistry::self()->sideBarForDockWidget(q)) {
             sb->removeDockWidget(q);


### PR DESCRIPTION
The bug is reproduced on kddockwidgets_example_quick

To Reproduce
1. tab dock 1 to dock 4
2. toggle dock 4

It only happens with the dock widget, which is the first in the tabbar

There is also some kind of bug with switching widgets in the tabbar. We have fixed it in MuseScore and will make a PR soon

Before

https://user-images.githubusercontent.com/10116828/123401423-1005c380-d5a7-11eb-9bd0-b03179a7d83b.mp4

After

https://user-images.githubusercontent.com/10116828/123401459-1b58ef00-d5a7-11eb-859d-c604b745f1c5.mp4


