### PR TITLE
Allow switching tabs via context menu in the tabs area

### DIFF
--- a/examples/dockwidgets/main.cpp
+++ b/examples/dockwidgets/main.cpp
@@ -120,12 +120,16 @@ int main(int argc, char **argv)
     parser.addOption(dontCloseBeforeRestore);
 
     QCommandLineOption showButtonsInTabBarIfTitleBarHidden("show-buttons-in-tabbar-if-titlebar-hidden",
-                                              QCoreApplication::translate("main", "If we're not using title bars we'll still show the close and float button in the tab bar"));
+                                                           QCoreApplication::translate("main", "If we're not using title bars we'll still show the close and float button in the tab bar"));
     parser.addOption(showButtonsInTabBarIfTitleBarHidden);
 
     QCommandLineOption centralWidget("central-widget",
                                      QCoreApplication::translate("main", "The main window will have a non-detachable central widget"));
     parser.addOption(centralWidget);
+
+    QCommandLineOption ctxtMenuOnTabs("allow-switch-tabs-via-menu",
+                                      QCoreApplication::translate("main", "Allow switching tabs via context menu in tabs area"));
+    parser.addOption(ctxtMenuOnTabs);
 
 #if defined(DOCKS_DEVELOPER_MODE)
     parser.addOption(centralFrame);
@@ -236,6 +240,9 @@ int main(int argc, char **argv)
 
     if (parser.isSet(tabsHaveCloseButton))
         flags |= KDDockWidgets::Config::Flag_TabsHaveCloseButton;
+
+    if (parser.isSet(ctxtMenuOnTabs))
+        flags |= KDDockWidgets::Config::Flag_AllowSwitchingTabsViaMenu;
 
 
     if (parser.isSet(doubleClickMaximize))

--- a/src/Config.h
+++ b/src/Config.h
@@ -83,6 +83,7 @@ public:
         Flag_KeepAboveIfNotUtilityWindow = 0x10000, ///< Only meaningful if Flag_DontUseUtilityFloatingWindows is set. If floating windows are normal windows, you might still want them to keep above and not minimize when you focus the main window.
         Flag_CloseOnlyCurrentTab = 0x20000, ///< The TitleBar's close button will only close the current tab, instead of all of them
         Flag_ShowButtonsOnTabBarIfTitleBarHidden = 0x40000, ///< When using Flag_HideTitleBarWhenTabsVisible the close/float buttons disappear with the title bar. With Flag_ShowButtonsOnTabBarIfHidden they'll be shown in the tab bar.
+        Flag_AllowSwitchingTabsViaMenu = 0x80000, ///< Allow switching tabs via a context menu when right clicking on the tab area
         Flag_Default = Flag_AeroSnapWithClientDecos ///< The defaults
     };
     Q_DECLARE_FLAGS(Flags, Flag)

--- a/src/MainWindowBase.cpp
+++ b/src/MainWindowBase.cpp
@@ -372,7 +372,7 @@ SideBarLocation MainWindowBase::Private::preferredSideBar(DockWidgetBase *dw) co
     }
 
     const Layouting::LayoutBorderLocations borders = item->adjacentLayoutBorders();
-    const qreal aspectRatio = dw->width() / (dw->height() * 1.0);
+    const qreal aspectRatio = dw->width() / (std::max(1, dw->height()) * 1.0);
 
     /// 1. It's touching all borders
     if (borders == Layouting::LayoutBorderLocation_All) {

--- a/src/private/widgets/TabWidgetWidget_p.h
+++ b/src/private/widgets/TabWidgetWidget_p.h
@@ -65,6 +65,8 @@ protected:
     DockWidgetBase *dockwidgetAt(int index) const override;
     int currentIndex() const override;
 
+    virtual void contextMenuRequested(QPoint pos);
+
 private:
     void updateMargins();
     void setupTabBarButtons();

--- a/tests/tst_docks.cpp
+++ b/tests/tst_docks.cpp
@@ -5120,6 +5120,7 @@ void TestDocks::tst_restoreSideBar()
 
         serialized = saver.serializeLayout();
 
+        m1.reset();
         delete fw1;
     }
 
@@ -5236,6 +5237,7 @@ void TestDocks::tst_sidebarOverlayGetsHiddenOnClick()
         Tests::clickOn(widget2->mapToGlobal(widget2->rect().bottomLeft() + QPoint(5, -5)), widget2);
         QVERIFY(!dw1->isOverlayed());
 
+        m1.reset();
         delete dw1;
     }
 
@@ -5255,8 +5257,6 @@ void TestDocks::tst_sidebarOverlayGetsHiddenOnClick()
         const QPoint localPt(100, 250);
         Tests::clickOn(m1->mapToGlobal(m1->rect().topLeft() + localPt), m1->childAt(localPt));
         QVERIFY(!dw1->isOverlayed());
-
-        delete dw1;
     }
 }
 


### PR DESCRIPTION
This change allows you to switch tabs via the context menu. The context
menu only shows up if you click on the empty area beside the tabs.

Signed-off-by: Waqar Ahmed <waqar.ahmed@kdab.com>