### PR TITLE
Install library so into python module dir

### DIFF
--- a/cmake/KDAB/modules/PySide2ModuleBuild.cmake
+++ b/cmake/KDAB/modules/PySide2ModuleBuild.cmake
@@ -129,6 +129,7 @@ macro(CREATE_PYTHON_BINDINGS
             PREFIX ""
             OUTPUT_NAME ${MODULE_NAME}
             LIBRARY_OUTPUT_DIRECTORY ${MODULE_OUTPUT_DIR}
+            INSTALL_RPATH "$ORIGIN"
         )
 
         if(WIN32)

--- a/python/PyKDDockWidgets/CMakeLists.txt
+++ b/python/PyKDDockWidgets/CMakeLists.txt
@@ -81,5 +81,11 @@ create_python_bindings(
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/__init__.py.cmake ${CMAKE_CURRENT_BINARY_DIR}/__init__.py @ONLY)
 
 # install
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/__init__.py
-    DESTINATION ${${PROJECT_NAME}_PYTHON_BINDINGS_INSTALL_PREFIX})
+install(
+    FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/__init__.py
+        $<TARGET_LINKER_FILE:KDAB::kddockwidgets>
+        $<TARGET_SONAME_FILE:KDAB::kddockwidgets>
+        $<TARGET_FILE:KDAB::kddockwidgets>
+    DESTINATION
+        ${${PROJECT_NAME}_PYTHON_BINDINGS_INSTALL_PREFIX})

--- a/python/PyKDDockWidgets/__init__.py.cmake
+++ b/python/PyKDDockWidgets/__init__.py.cmake
@@ -10,8 +10,14 @@
 #
 
 import sys
+import os
 
 __all__ = ['KDDockWidgets']
+
+def setupLibraryPath():
+    package_dir = os.path.abspath(os.path.dirname(__file__))
+    if sys.platform == 'win32':
+        os.add_dll_directory(package_dir)
 
 # Preload PySide libraries to avoid missing libraries while loading KDDockWidgets
 try:
@@ -22,3 +28,5 @@ try:
 except Exception:
     print("Failed to load PySide")
     raise
+
+setupLibraryPath()


### PR DESCRIPTION
We do the same a PySide and install the target library into the python
module this. This way the bindings can work without need to export
system paths.