### PR TITLE
Ensure that floating windows are non positioned off-screen when they …

### DIFF
--- a/src/DockWidgetBase.cpp
+++ b/src/DockWidgetBase.cpp
@@ -513,6 +513,7 @@ FloatingWindow *DockWidgetBase::Private::morphIntoFloatingWindow()
         auto frame = Config::self().frameworkWidgetFactory()->createFrame();
         frame->addWidget(q);
         geo.setSize(geo.size().boundedTo(frame->maxSizeHint()));
+        FloatingWindow::ensureRectIsOnScreen(geo);
         auto floatingWindow =
             Config::self().frameworkWidgetFactory()->createFloatingWindow(frame, nullptr, geo);
         floatingWindow->show();

--- a/src/LayoutSaver.cpp
+++ b/src/LayoutSaver.cpp
@@ -339,10 +339,13 @@ void LayoutSaver::Private::deserializeWindowGeometry(const T &saved, QWidgetOrQu
     // Not simply calling QWidget::setGeometry() here.
     // For QtQuick we need to modify the QWindow's geometry.
 
+    auto windowGeometry = saved.geometry;
+    ::FloatingWindow::ensureRectIsOnScreen(windowGeometry);
+
     if (topLevel->isWindow()) {
-        topLevel->setGeometry(saved.geometry);
+        topLevel->setGeometry(windowGeometry);
     } else {
-        KDDockWidgets::Private::setTopLevelGeometry(saved.geometry, topLevel);
+        KDDockWidgets::Private::setTopLevelGeometry(windowGeometry, topLevel);
     }
 
     topLevel->setVisible(saved.isVisible);

--- a/src/private/FloatingWindow.cpp
+++ b/src/private/FloatingWindow.cpp
@@ -261,6 +261,8 @@ void FloatingWindow::setSuggestedGeometry(QRect suggestedRect, SuggestedGeometry
             suggestedRect.moveCenter(originalCenter);
     }
 
+    ensureRectIsOnScreen(suggestedRect);
+
     setGeometry(suggestedRect);
 }
 
@@ -634,4 +636,52 @@ void FloatingWindow::updateSizeConstraints()
         // Doing it manually instead.
         setMaximumSize(maxSizeHint());
     });
+}
+
+void FloatingWindow::ensureRectIsOnScreen(QRect &geometry)
+{
+    const auto screens = qApp->screens();
+    if (screens.empty())
+        return;
+
+    bool isOnScreen = false;
+
+    int nearestDistSq = std::numeric_limits<int>::max();
+    int nearestIndex = -1;
+
+    for (int i = 0; i < screens.count(); i++) {
+        auto scrGeom = screens[i]->geometry();
+
+        // Account for virtual coordinates space
+        scrGeom.moveTopLeft(scrGeom.topLeft() - screens[i]->virtualGeometry().topLeft());
+
+        // If the rectangle is visible at all, we need do nothing
+        if (scrGeom.intersects((geometry)))
+            return;
+
+        // Find the nearest screen, so we can move the geometry onto it
+        auto dist2D = geometry.center() - scrGeom.center();
+        auto distSq = dist2D.x() * dist2D.x() + dist2D.y() + dist2D.y();
+        if (distSq < nearestDistSq) {
+            nearestDistSq = distSq;
+            nearestIndex = i;
+        }
+    }
+
+    // Move the rectangle to the nearest vertical and/or horizontal screen edge
+    Q_ASSERT(nearestIndex != -1);
+    auto scrGeom = screens[nearestIndex]->geometry();
+    scrGeom.moveTopLeft(scrGeom.topLeft() - screens[nearestIndex]->virtualGeometry().topLeft());
+
+    if (geometry.left() < scrGeom.left()) {
+        geometry.moveLeft(scrGeom.left());
+    } else if (geometry.left() > scrGeom.right()) {
+        geometry.moveRight(scrGeom.right());
+    }
+
+    if (geometry.top() < scrGeom.top()) {
+        geometry.moveTop(scrGeom.top());
+    } else if (geometry.top() > scrGeom.bottom()) {
+        geometry.moveBottom(scrGeom.bottom());
+    }
 }

--- a/src/private/FloatingWindow_p.h
+++ b/src/private/FloatingWindow_p.h
@@ -62,6 +62,8 @@ public:
 
     int userType() const;
 
+    static void ensureRectIsOnScreen(QRect &geometry);
+
 #ifdef Q_OS_WIN
     void setLastHitTest(int hitTest)
     {


### PR DESCRIPTION
…are shown

At points when a Rect is to be used to position a floating widget, test to see if it overlaps any of the system's screens. If it does not, adjust the Rect to within the closest screen edges.