### PR TITLE
Add API to set center widget margins on MainWindow

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -72,7 +72,8 @@ public:
 
     void updateMargins()
     {
-        m_layout->setContentsMargins(q->centerWidgetMargins());
+        const qreal factor = logicalDpiFactor(q);
+        m_layout->setContentsMargins(m_centerWidgetMargins * factor);
     }
 
     MainWindow *const q;
@@ -80,6 +81,7 @@ public:
     QHash<SideBarLocation, SideBar *> m_sideBars;
     MyCentralWidget *const m_centralWidget;
     QHBoxLayout *const m_layout;
+    QMargins m_centerWidgetMargins = { 1, 5, 1, 1 };
 };
 
 MyCentralWidget::~MyCentralWidget()
@@ -139,8 +141,15 @@ void MainWindow::resizeEvent(QResizeEvent *ev)
 
 QMargins MainWindow::centerWidgetMargins() const
 {
-    const QMargins margins = { 1, 5, 1, 1 };
-    return margins * logicalDpiFactor(this);
+    return d->m_centerWidgetMargins;
+}
+
+void MainWindow::setCenterWidgetMargins(const QMargins &margins)
+{
+    if (d->m_centerWidgetMargins == margins)
+        return;
+    d->m_centerWidgetMargins = margins;
+    d->updateMargins();
 }
 
 QRect MainWindow::centralAreaGeometry() const

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -50,9 +50,14 @@ public:
     ///@brief returns the sidebar for the specified location
     SideBar *sideBar(SideBarLocation) const override;
 
+    //@brief returns the margins for the contents widget
+    QMargins centerWidgetMargins() const override;
+
+    //@brief sets the margins for the contents widgets
+    void setCenterWidgetMargins(const QMargins &margins);
+
 protected:
     void resizeEvent(QResizeEvent *) override;
-    QMargins centerWidgetMargins() const override;
     QRect centralAreaGeometry() const override;
 
 private:


### PR DESCRIPTION
We can't change the margins by subclassing MainWindow and overriding
centerWidgetMargins, since the margins are initialized in MainWindow's
constructor. This adds public API to MainWindow to allow us to change
the margins later on.