### PR TITLE
Don't render frame for central persistent widget

### DIFF
--- a/src/FrameworkWidgetFactory.cpp
+++ b/src/FrameworkWidgetFactory.cpp
@@ -75,9 +75,9 @@ TabBar *DefaultWidgetFactory::createTabBar(TabWidget *parent) const
     return new TabBarWidget(parent);
 }
 
-TabWidget *DefaultWidgetFactory::createTabWidget(Frame *parent) const
+TabWidget *DefaultWidgetFactory::createTabWidget(Frame *parent, TabWidgetOptions options) const
 {
-    return new TabWidgetWidget(parent);
+    return new TabWidgetWidget(parent, options);
 }
 
 Layouting::Separator *DefaultWidgetFactory::createSeparator(Layouting::Widget *parent) const

--- a/src/FrameworkWidgetFactory.h
+++ b/src/FrameworkWidgetFactory.h
@@ -97,7 +97,7 @@ public:
     ///@brief Called internally by the framework to create a TabWidget
     ///       Override to provide your own TabWidget sub-class.
     ///@param parent Just forward to TabWidget's constructor.
-    virtual TabWidget *createTabWidget(Frame *parent) const = 0;
+    virtual TabWidget *createTabWidget(Frame *parent, TabWidgetOptions options = TabWidgetOption_None) const = 0;
 
     ///@brief Called internally by the framework to create a TabBar
     ///       Override to provide your own TabBar sub-class.
@@ -167,7 +167,7 @@ public:
     Frame *createFrame(QWidgetOrQuick *parent, FrameOptions) const override;
     TitleBar *createTitleBar(Frame *) const override;
     TitleBar *createTitleBar(FloatingWindow *) const override;
-    TabWidget *createTabWidget(Frame *parent) const override;
+    TabWidget *createTabWidget(Frame *parent, TabWidgetOptions) const override;
     TabBar *createTabBar(TabWidget *parent) const override;
     Layouting::Separator *createSeparator(Layouting::Widget *parent = nullptr) const override;
     FloatingWindow *createFloatingWindow(MainWindowBase *parent = nullptr) const override;

--- a/src/KDDockWidgets.h
+++ b/src/KDDockWidgets.h
@@ -267,6 +267,15 @@ Q_DECLARE_FLAGS(FrameOptions, FrameOption)
 Q_ENUM_NS(FrameOptions)
 
 ///@internal
+enum TabWidgetOption
+{
+    TabWidgetOption_None = 0,
+    TabWidgetOption_NoFrame = 1,
+};
+Q_DECLARE_FLAGS(TabWidgetOptions, TabWidgetOption)
+Q_ENUM_NS(TabWidgetOptions)
+
+///@internal
 inline QString locationStr(Location loc)
 {
     switch (loc) {

--- a/src/private/Frame.cpp
+++ b/src/private/Frame.cpp
@@ -50,12 +50,19 @@ static FrameOptions actualOptions(FrameOptions options)
 
     return options;
 }
+
+static TabWidgetOptions tabWidgetOptions(FrameOptions options)
+{
+    if (options & FrameOption_NonDockable)
+        return TabWidgetOption_NoFrame;
+    return TabWidgetOption_None;
+}
 }
 
 Frame::Frame(QWidgetOrQuick *parent, FrameOptions options, int userType)
     : LayoutGuestWidget(parent)
     , FocusScope(this)
-    , m_tabWidget(Config::self().frameworkWidgetFactory()->createTabWidget(this))
+    , m_tabWidget(Config::self().frameworkWidgetFactory()->createTabWidget(this, tabWidgetOptions(options)))
     , m_titleBar(Config::self().frameworkWidgetFactory()->createTitleBar(this))
     , m_options(actualOptions(options))
     , m_userType(userType)

--- a/src/private/widgets/TabWidgetWidget.cpp
+++ b/src/private/widgets/TabWidgetWidget.cpp
@@ -31,7 +31,7 @@
 
 using namespace KDDockWidgets;
 
-TabWidgetWidget::TabWidgetWidget(Frame *parent)
+TabWidgetWidget::TabWidgetWidget(Frame *parent, TabWidgetOptions options)
     : QTabWidget(parent)
     , TabWidget(this, parent)
     , m_tabBar(Config::self().frameworkWidgetFactory()->createTabBar(this))
@@ -65,6 +65,8 @@ TabWidgetWidget::TabWidgetWidget(Frame *parent)
         setFocusProxy(nullptr);
 
     setupTabBarButtons();
+
+    setDocumentMode(options & TabWidgetOption_NoFrame);
 }
 
 TabBar *TabWidgetWidget::tabBar() const

--- a/src/private/widgets/TabWidgetWidget_p.h
+++ b/src/private/widgets/TabWidgetWidget_p.h
@@ -39,7 +39,7 @@ class DOCKS_EXPORT TabWidgetWidget
 {
     Q_OBJECT
 public:
-    explicit TabWidgetWidget(Frame *parent);
+    explicit TabWidgetWidget(Frame *parent, TabWidgetOptions options);
 
     TabBar *tabBar() const override;
 


### PR DESCRIPTION
When the main window has a central persistent widget, make sure the
containing tab widget doesn't render a frame around it.