### PR TITLE
Corrected the updating of normal geometry for window

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -299,7 +299,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR IS_CLANG_BUILD)
 endif()
 
 if(${PROJECT_NAME}_QTQUICK)
-  target_link_libraries(kddockwidgets PUBLIC Qt${Qt_VERSION_MAJOR}::Widgets Qt${Qt_VERSION_MAJOR}::Quick Qt${Qt_VERSION_MAJOR}::QuickControls2)
+  target_link_libraries(kddockwidgets PUBLIC Qt${Qt_VERSION_MAJOR}::Widgets Qt${Qt_VERSION_MAJOR}::Quick Qt${Qt_VERSION_MAJOR}::QuickControls2 PRIVATE Qt${Qt_VERSION_MAJOR}::GuiPrivate)
 else()
   target_link_libraries(kddockwidgets PUBLIC Qt${Qt_VERSION_MAJOR}::Widgets PRIVATE Qt${Qt_VERSION_MAJOR}::WidgetsPrivate)
 endif()

--- a/src/private/quick/QWidgetAdapter_quick.cpp
+++ b/src/private/quick/QWidgetAdapter_quick.cpp
@@ -33,6 +33,8 @@
 #include <QQuickView>
 #include <QScopedValueRollback>
 
+#include <qpa/qplatformwindow.h>
+
 using namespace KDDockWidgets;
 
 namespace KDDockWidgets {
@@ -180,54 +182,13 @@ void QWidgetAdapter::onMouseRelease()
 void QWidgetAdapter::onCloseEvent(QCloseEvent *)
 {
 }
-void QWidgetAdapter::onResizeEvent(QResizeEvent *event)
+void QWidgetAdapter::onResizeEvent(QResizeEvent *)
 {
-    QWindow* window = windowHandle();
-    if (!window) {
-        return;
-    }
-
-    if (isNormalWindowState(m_oldWindowState)) {
-        QRect geo = normalGeometry();
-
-        auto curState = window->windowState();
-        if (isNormalWindowState(curState)) {
-            geo.setSize(event->size());
-        } else {
-            geo.setSize(event->oldSize());
-        }
-
-        setNormalGeometry(geo);
-    }
+    updateNormalGeometry();
 }
-void QWidgetAdapter::onMoveEvent(QMoveEvent *event)
+void QWidgetAdapter::onMoveEvent(QMoveEvent *)
 {
-    QWindow* window = windowHandle();
-    if (!window) {
-        return;
-    }
-
-    if (isNormalWindowState(m_oldWindowState)) {
-        QRect geo = normalGeometry();
-
-        auto windowCurrentState = window->windowState();
-        if (isNormalWindowState(windowCurrentState)) {
-            geo.moveTopLeft(event->pos());
-        } else {
-            geo.moveTopLeft(event->oldPos());
-        }
-
-        setNormalGeometry(geo);
-    }
-}
-void QWidgetAdapter::onWindowStateChangeEvent(QWindowStateChangeEvent *)
-{
-    QWindow* window = windowHandle();
-    if (!window) {
-        return;
-    }
-
-    m_oldWindowState = window->windowState();
+    updateNormalGeometry();
 }
 
 void QWidgetAdapter::itemChange(QQuickItem::ItemChange change, const QQuickItem::ItemChangeData &data)
@@ -255,6 +216,27 @@ void QWidgetAdapter::itemChange(QQuickItem::ItemChange change, const QQuickItem:
     }
     default:
         break;
+    }
+}
+
+void QWidgetAdapter::updateNormalGeometry()
+{
+    QWindow *window = windowHandle();
+    if (!window) {
+        return;
+    }
+
+    QRect normalGeometry;
+    if (const QPlatformWindow *pw = window->handle()) {
+        normalGeometry = pw->normalGeometry();
+    }
+
+    if (!normalGeometry.isValid() && isNormalWindowState(window->windowState())) {
+        normalGeometry = window->geometry();
+    }
+
+    if (normalGeometry.isValid()) {
+        setNormalGeometry(normalGeometry);
     }
 }
 
@@ -794,8 +776,6 @@ bool QWidgetAdapter::eventFilter(QObject *watched, QEvent *ev)
             onResizeEvent(static_cast<QResizeEvent *>(ev));
         } else if (ev->type() == QEvent::Move) {
             onMoveEvent(static_cast<QMoveEvent *>(ev));
-        } else if (ev->type() == QEvent::WindowStateChange) {
-            onWindowStateChangeEvent(static_cast<QWindowStateChangeEvent *>(ev));
         }
     }
 

--- a/src/private/quick/QWidgetAdapter_quick_p.h
+++ b/src/private/quick/QWidgetAdapter_quick_p.h
@@ -253,10 +253,11 @@ protected:
     virtual void onCloseEvent(QCloseEvent *);
     virtual void onResizeEvent(QResizeEvent *);
     virtual void onMoveEvent(QMoveEvent *);
-    virtual void onWindowStateChangeEvent(QWindowStateChangeEvent *);
     void itemChange(QQuickItem::ItemChange, const QQuickItem::ItemChangeData &) override;
 
 private:
+    void updateNormalGeometry();
+
     QSize m_sizeHint;
     QSizePolicy m_sizePolicy = QSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
     ;
@@ -269,7 +270,6 @@ private:
     bool m_inSetParent = false;
     MouseEventRedirector *m_mouseEventRedirector = nullptr;
     QRect m_normalGeometry;
-    Qt::WindowStates m_oldWindowState = Qt::WindowState::WindowNoState;
 };
 
 inline qreal logicalDpiFactor(const QQuickItem *item)


### PR DESCRIPTION
Found some bugs in my previous PR #259.
This is mainly due to the saving of geometry when toggling full screen/maximized state.

Steps to reproduce:
1. Open app
2. Go to Full Screen/maximized
3. Close app. The app should save normal geometry and state
4. Open app

It is expected that the program will open on full screen/maximized state. When leaving full screen/maximized state, the geometry should be the same as it was before toggling to full screen/maximized state.

This is how it works in this PR. The solution is taken from the QWidget class.
It works well on Windows/Linux, but not for MacOS.

For MacOS, the state changes after the program has changed its size:
Move and resize events come with a WindowNoState state when going to fullscreen/maximized.

And this condition is not working properly
```
    if (!normalGeometry.isValid() && isNormalWindowState(window->windowState())) {
        normalGeometry = window->geometry();
    }

```

I didn't find a solution for macOS. But I will be glad if you(@iamsergio) have ideas on how to fix this bug.