### PR TITLE
Fix position of right overlay dockwidgets when there's a toolbar on the left

### DIFF
--- a/src/MainWindowBase.cpp
+++ b/src/MainWindowBase.cpp
@@ -307,7 +307,7 @@ QRect MainWindowBase::Private::rectForOverlay(Frame *frame, SideBarLocation loca
         rect.setHeight(centralAreaGeo.height() - topSideBarHeight - bottomSideBarHeight - centerWidgetMargins.top() - centerWidgetMargins.bottom());
         rect.moveTop(sb->mapTo(q, QPoint(0, 0)).y() + topSideBarHeight - 1);
         if (location == SideBarLocation::East) {
-            rect.moveLeft(centralAreaGeo.width() - rect.width() - sb->width() - centerWidgetMargins.right() - margin);
+            rect.moveLeft(centralAreaGeo.x() + centralAreaGeo.width() - rect.width() - sb->width() - centerWidgetMargins.right() - margin);
         } else {
             rect.moveLeft(margin + centralAreaGeo.x() + centerWidgetMargins.left() + sb->width());
         }


### PR DESCRIPTION
Was wondering if we would need an autotest for this but seems a bit strange since it would be basically testing the calculation against itself.