### PR TITLE
Allow custom sidebars to access its dock widgets

### DIFF
--- a/src/private/SideBar.cpp
+++ b/src/private/SideBar.cpp
@@ -68,6 +68,11 @@ void SideBar::onButtonClicked(DockWidgetBase *dw)
     toggleOverlay(dw);
 }
 
+QVector<DockWidgetBase *> SideBar::dockWidgets() const
+{
+    return m_dockWidgets;
+}
+
 void SideBar::onDockWidgetDestroyed(QObject *dw)
 {
     removeDockWidget(static_cast<DockWidgetBase *>(dw));

--- a/src/private/SideBar_p.h
+++ b/src/private/SideBar_p.h
@@ -66,6 +66,8 @@ protected:
 
     void onButtonClicked(DockWidgetBase *dw);
 
+    QVector<DockWidgetBase *> dockWidgets() const;
+
 private:
     void onDockWidgetDestroyed(QObject *dw);
     void updateSize();

--- a/src/private/widgets/SideBarWidget_p.h
+++ b/src/private/widgets/SideBarWidget_p.h
@@ -29,7 +29,7 @@ class DockWidget;
 class Frame;
 class SideBarWidget;
 
-class SideBarButton : public QToolButton
+class DOCKS_EXPORT SideBarButton : public QToolButton
 {
     Q_OBJECT
 public:


### PR DESCRIPTION
This is useful in cases where a custom sidebar wants behavior that
affects multiple dock widgets it "contains".

Also contains a small change to allow subclassing `SideBarButton`.