### PR TITLE
Fixed restoring the normal geometry if fractional scaling is enabled

### DIFF
--- a/src/private/quick/QWidgetAdapter_quick.cpp
+++ b/src/private/quick/QWidgetAdapter_quick.cpp
@@ -35,6 +35,7 @@
 #include <QScopedValueRollback>
 
 #include <qpa/qplatformwindow.h>
+#include <QtGui/private/qhighdpiscaling_p.h>
 
 using namespace KDDockWidgets;
 
@@ -229,7 +230,7 @@ void QWidgetAdapter::updateNormalGeometry()
 
     QRect normalGeometry;
     if (const QPlatformWindow *pw = window->handle()) {
-        normalGeometry = pw->normalGeometry();
+        normalGeometry = QHighDpi::fromNativePixels(pw->normalGeometry(), pw->window());
     }
 
     if (!normalGeometry.isValid() && isNormalWindowState(window->windowState())) {


### PR DESCRIPTION
The issue is reproduced on kddockwidgets_example_quick if enable fractional scalling

```
int main(int argc, char *argv[])
{
    ...
    QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
    ...
}
```

Before: 

https://user-images.githubusercontent.com/10116828/193337531-a5599378-06bb-4b46-a63d-24051e0e1e2a.mp4

After:

https://user-images.githubusercontent.com/10116828/193337835-ad8262a3-4bb0-4dea-943d-5733733fc8bd.mp4
