### PR TITLE
Fix layout scaling factor when main window is native

### DIFF
--- a/src/LayoutSaver.cpp
+++ b/src/LayoutSaver.cpp
@@ -1068,7 +1068,7 @@ LayoutSaver::ScalingInfo::ScalingInfo(const QString &mainWindowId, QRect savedMa
 
     this->mainWindowName = mainWindowId;
     this->savedMainWindowGeometry = savedMainWindowGeo;
-    realMainWindowGeometry = mainWindow->window()->geometry(); // window() as our main window might be embedded
+    realMainWindowGeometry = mainWindow->windowGeometry();
     widthFactor = double(realMainWindowGeometry.width()) / savedMainWindowGeo.width();
     heightFactor = double(realMainWindowGeometry.height()) / savedMainWindowGeo.height();
     mainWindowChangedScreen = currentScreenIndex != screenIndex;


### PR DESCRIPTION
When a main window is serialized, we get the geometry to be serialized with MainWindowBase::windowGeometry. When the layout is restored, we get the geometry of the current window with window()->geometry() and use it to compute the scaling factor.

The values returned by MainWindowBase::windowGeometry and window()->geometry() will differ if the main window is a native widget, but not a toplevel window. In this case, windowGeometry returns the geometry of the main window widget, not of its containing window.

Use MainWindowBase::windowGeometry when computing the scaling factor, so that these geometries are consistent and the scaling factor is correct.