### PR TITLE
Allow restoring layouts without touching floating dock widgets

### DIFF
--- a/src/KDDockWidgets.h
+++ b/src/KDDockWidgets.h
@@ -182,8 +182,9 @@ private:
 
 enum RestoreOption {
     RestoreOption_None = 0,
-    RestoreOption_RelativeToMainWindow = 1, ///< Skips restoring the main window geometry and the restored dock widgets will use relative sizing.
-                                            ///< Loading layouts won't change the main window geometry and just use whatever the user has at the moment.
+    RestoreOption_RelativeToMainWindow = 1 << 0, ///< Skips restoring the main window geometry and the restored dock widgets will use relative sizing.
+                                                 ///< Loading layouts won't change the main window geometry and just use whatever the user has at the moment.
+    RestoreOption_AbsoluteFloatingDockWindows = 1 << 1, ///< Skips scaling of floating dock windows relative to the main window.
 };
 Q_DECLARE_FLAGS(RestoreOptions, RestoreOption)
 Q_ENUM_NS(RestoreOptions)

--- a/src/LayoutSaver.cpp
+++ b/src/LayoutSaver.cpp
@@ -66,15 +66,22 @@ LayoutSaver::Layout *LayoutSaver::Layout::s_currentLayoutBeingRestored = nullptr
 
 inline InternalRestoreOptions internalRestoreOptions(RestoreOptions options)
 {
-    if (options == RestoreOption_None) {
-        return InternalRestoreOption::None;
-    } else if (options == RestoreOption_RelativeToMainWindow) {
-        return InternalRestoreOptions(InternalRestoreOption::SkipMainWindowGeometry)
-            | InternalRestoreOption::RelativeFloatingWindowGeometry;
-    } else {
-        qWarning() << Q_FUNC_INFO << "Unknown options" << options;
-        return {};
+    InternalRestoreOptions ret = {};
+    if (options.testFlag(RestoreOption_RelativeToMainWindow)) {
+        ret.setFlag(InternalRestoreOption::SkipMainWindowGeometry);
+        ret.setFlag(InternalRestoreOption::RelativeFloatingWindowGeometry);
+        options.setFlag(RestoreOption_RelativeToMainWindow, false);
     }
+    if (options.testFlag(RestoreOption_AbsoluteFloatingDockWindows)) {
+        ret.setFlag(InternalRestoreOption::RelativeFloatingWindowGeometry, false);
+        options.setFlag(RestoreOption_AbsoluteFloatingDockWindows, false);
+    }
+
+    if (options != RestoreOption_None) {
+        qWarning() << Q_FUNC_INFO << "Unknown options" << options;
+    }
+
+    return ret;
 }
 
 bool LayoutSaver::Private::s_restoreInProgress = false;


### PR DESCRIPTION
The current behavior is great for when we want to apply an older stored state to a different screen configuration. There, scaling/shrinking the floating docks makes sense.

But we now also want to have more fine grained window configurations and save/restore them more frequently. In those situations, the screen config is the same, but the mainwindow may or may not be full screen when the state was saved. In this case we don't want to touch the size of the floating docks - most notably we don't want to resize a "nearly fullscreen" floating window from a state with a small main window when loading it into a state with a fullscreen mainwindow - in such situations the floating window would get resized beyond the available screen space!

Preventing the latter is probably required as a safety measure independently of this patch, for situations where the relative resizing is desired. This is outside the scope of this patch.