### PR TITLE
Fix includes for add_subdirectory builds

### DIFF
--- a/src/3rdparty/kdbindings/signal.h
+++ b/src/3rdparty/kdbindings/signal.h
@@ -19,8 +19,8 @@
 #include <type_traits>
 #include <utility>
 
-#include <kdbindings/genindex_array.h>
-#include <kdbindings/utils.h>
+#include "genindex_array.h"
+#include "utils.h"
 
 /**
  * @brief The main namespace of the KDBindings library.

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -22,7 +22,7 @@
 #include "DockRegistry.h"
 #include "private/Utils_p.h"
 #include "private/DragController_p.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 #include "core/Separator.h"
 #include "core/Platform.h"
 

--- a/src/LayoutSaver.cpp
+++ b/src/LayoutSaver.cpp
@@ -18,7 +18,7 @@
 
 #include "LayoutSaver.h"
 #include "Config.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 #include "nlohmann_qt_helpers.h"
 
 #include "private/multisplitter/Item_p.h"

--- a/src/core/DockWidget.cpp
+++ b/src/core/DockWidget.cpp
@@ -30,7 +30,7 @@
 #include "private/multisplitter/Item_p.h"
 
 #include "Config.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 
 #include <QTimer>
 #include <QScopedValueRollback>

--- a/src/core/DropArea.cpp
+++ b/src/core/DropArea.cpp
@@ -11,7 +11,7 @@
 
 #include "DropArea.h"
 #include "Config.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 #include "DockRegistry.h"
 #include "Platform.h"
 #include "private/Draggable_p.h"

--- a/src/core/FloatingWindow.cpp
+++ b/src/core/FloatingWindow.cpp
@@ -21,7 +21,7 @@
 #include "private/WidgetResizeHandler_p.h"
 #include "DockRegistry.h"
 #include "Config.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 #include "private/DragController_p.h"
 #include "private/LayoutSaver_p.h"
 #include "DockWidget_p.h"

--- a/src/core/FocusScope.cpp
+++ b/src/core/FocusScope.cpp
@@ -24,7 +24,6 @@
 #include "DockRegistry.h"
 #include "private/Platform_p.h"
 
-using namespace KDDockWidgets;
 using namespace KDDockWidgets::Core;
 
 // Our Private inherits from QObject since FocusScope can't (Since Frame is already QObject)

--- a/src/core/FocusScope.h
+++ b/src/core/FocusScope.h
@@ -20,7 +20,7 @@
 #define KD_DOCKWIDGETS_FOCUSSCOPE_H
 
 #include "kddockwidgets/docks_export.h"
-#include "View.h"
+#include "kddockwidgets/View.h"
 
 namespace KDDockWidgets::Core {
 

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -12,7 +12,7 @@
 #include "Group.h"
 
 #include "kddockwidgets/Config.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 
 #include "Controller.h"
 #include "View.h"

--- a/src/core/Layout.cpp
+++ b/src/core/Layout.cpp
@@ -13,7 +13,7 @@
 #include "private/Position_p.h"
 #include "Config.h"
 #include "Platform.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 #include "private/Utils_p.h"
 #include "private/View_p.h"
 

--- a/src/core/MDILayout.cpp
+++ b/src/core/MDILayout.cpp
@@ -12,7 +12,7 @@
 #include "MDILayout.h"
 #include "private/multisplitter/ItemFreeContainer_p.h"
 #include "Config.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "core/ViewFactory.h"
 #include "core/Group.h"
 #include "core/DockWidget_p.h"
 

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -25,7 +25,7 @@
 #include "private/Utils_p.h"
 #include "private/Logging_p.h"
 #include "private/WidgetResizeHandler_p.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 #include "private/LayoutSaver_p.h"
 #include "private/multisplitter/Item_p.h"
 #include "Platform.h"

--- a/src/core/Screen.h
+++ b/src/core/Screen.h
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include "docks_export.h"
+#include "kddockwidgets/docks_export.h"
 
 #include <QVector>
 

--- a/src/core/Separator.cpp
+++ b/src/core/Separator.cpp
@@ -16,7 +16,7 @@
 #include "Config.h"
 #include "Platform.h"
 #include "Controller.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 
 
 #ifdef Q_OS_WIN

--- a/src/core/SideBar.cpp
+++ b/src/core/SideBar.cpp
@@ -12,7 +12,7 @@
 #include "SideBar.h"
 #include "DockWidget.h"
 #include "MainWindow.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 #include "views/SideBarViewInterface.h"
 #include "Config.h"
 

--- a/src/core/Stack.cpp
+++ b/src/core/Stack.cpp
@@ -11,7 +11,7 @@
 
 #include "Stack.h"
 #include "Config.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 #include "private/Logging_p.h"
 #include "private/Utils_p.h"
 #include "private/WindowBeingDragged_p.h"

--- a/src/core/TabBar.cpp
+++ b/src/core/TabBar.cpp
@@ -21,7 +21,7 @@
 #include "private/DragController_p.h"
 #include "private/Utils_p.h"
 #include "Config.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 
 using namespace KDDockWidgets;
 using namespace KDDockWidgets::Core;

--- a/src/core/TitleBar.cpp
+++ b/src/core/TitleBar.cpp
@@ -11,7 +11,7 @@
 
 #include "TitleBar.h"
 #include "Config.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 #include "View.h"
 #include "private/WindowBeingDragged_p.h"
 #include "private/Utils_p.h"

--- a/src/core/Window.h
+++ b/src/core/Window.h
@@ -11,9 +11,9 @@
 
 #pragma once
 
-#include "View.h"
+#include "kddockwidgets/View.h"
 #include "Screen.h"
-#include "KDDockWidgets_p.h"
+#include "../KDDockWidgets_p.h"
 
 #include <QVector>
 

--- a/src/core/indicators/ClassicIndicators.cpp
+++ b/src/core/indicators/ClassicIndicators.cpp
@@ -11,7 +11,7 @@
 
 #include "ClassicIndicators.h"
 #include "Config.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 #include "views/ClassicIndicatorWindowViewInterface.h"
 
 #include "core/DropArea.h"

--- a/src/flutter/ViewFactory_flutter.h
+++ b/src/flutter/ViewFactory_flutter.h
@@ -13,7 +13,7 @@
 #define KDDOCKWIDGETS_ViewFactory_flutter_H
 #pragma once
 
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 #include "NonQtCompat_p.h"
 
 // clazy:excludeall=ctor-missing-parent-argument

--- a/src/flutter/views/DockWidget_flutter.cpp
+++ b/src/flutter/views/DockWidget_flutter.cpp
@@ -10,7 +10,7 @@
 */
 
 #include "DockWidget_flutter.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 
 #include "kddockwidgets/core/TitleBar.h"
 #include "kddockwidgets/core/DockWidget.h"

--- a/src/flutter/views/Group_flutter.cpp
+++ b/src/flutter/views/Group_flutter.cpp
@@ -31,7 +31,7 @@
 #include "Stack_flutter.h"
 
 #include "Config.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 #include "private/WidgetResizeHandler_p.h"
 
 #include <QDebug>

--- a/src/fwd_headers/kddockwidgets/qtquick/views/Group.h
+++ b/src/fwd_headers/kddockwidgets/qtquick/views/Group.h
@@ -9,13 +9,4 @@
   Contact KDAB at <info@kdab.com> for commercial licensing options.
 */
 
-#include "kddockwidgets/core/ViewFactory.h"
-
-using namespace KDDockWidgets;
-using namespace KDDockWidgets::Core;
-
-DropIndicatorType ViewFactory::s_dropIndicatorType = DropIndicatorType::Classic;
-
-ViewFactory::~ViewFactory()
-{
-}
+#include "../../../../qtquick/views/Group.h"

--- a/src/fwd_headers/qtwidgets_pretty/kddockwidgets/MainWindow.h
+++ b/src/fwd_headers/qtwidgets_pretty/kddockwidgets/MainWindow.h
@@ -9,4 +9,4 @@
   Contact KDAB at <info@kdab.com> for commercial licensing options.
 */
 
-#include "kddockwidgets/views/MainWindow.h"
+#include "kddockwidgets/core/MainWindow.h"

--- a/src/layoutlinter_main.cpp
+++ b/src/layoutlinter_main.cpp
@@ -10,7 +10,7 @@
 */
 
 #include "Config.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 
 #include "core/MainWindow.h"
 #include "core/DockWidget.h"

--- a/src/qtquick/MainWindowInstantiator.cpp
+++ b/src/qtquick/MainWindowInstantiator.cpp
@@ -10,7 +10,7 @@
 */
 
 #include "MainWindowInstantiator.h"
-#include "kddockwidgets/views/MainWindow.h"
+#include "kddockwidgets/core/MainWindow.h"
 #include "qtquick/views/MainWindowMDI.h"
 #include "kddockwidgets/core/DockWidget.h"
 #include "kddockwidgets/core/MainWindow.h"

--- a/src/qtquick/views/DockWidget.cpp
+++ b/src/qtquick/views/DockWidget.cpp
@@ -10,7 +10,7 @@
 */
 
 #include "DockWidget.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 
 #include "kddockwidgets/core/TitleBar.h"
 #include "kddockwidgets/core/DockWidget.h"

--- a/src/qtquick/views/Group.cpp
+++ b/src/qtquick/views/Group.cpp
@@ -33,7 +33,7 @@
 #include "Stack.h"
 
 #include "Config.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 #include "private/WidgetResizeHandler_p.h"
 
 #include <QDebug>

--- a/src/qtquick/views/Group.h
+++ b/src/qtquick/views/Group.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include "View.h"
-#include "views/GroupViewInterface.h"
+#include "kddockwidgets/views/GroupViewInterface.h"
 #include "TitleBar.h"
 
 QT_BEGIN_NAMESPACE

--- a/src/qtquick/views/Stack.cpp
+++ b/src/qtquick/views/Stack.cpp
@@ -11,7 +11,7 @@
 
 #include "Stack.h"
 #include "Config.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 
 #include "kddockwidgets/core/Stack.h"
 #include "kddockwidgets/core/Group.h"

--- a/src/qtquick/views/TabBar.h
+++ b/src/qtquick/views/TabBar.h
@@ -22,13 +22,13 @@
 #pragma once
 
 #include "View.h"
-#include "views/TabBarViewInterface.h"
+#include "kddockwidgets/views/TabBarViewInterface.h"
 
 #include <QAbstractListModel>
 #include <QPointer>
 #include <QHash>
 
-#include "kdbindings/signal.h"
+#include "../../3rdparty/kdbindings/signal.h"
 
 namespace KDDockWidgets::Core {
 class TabBar;

--- a/src/qtquick/views/TitleBar.h
+++ b/src/qtquick/views/TitleBar.h
@@ -14,7 +14,7 @@
 #pragma once
 
 #include "kddockwidgets/docks_export.h"
-#include "views/TitleBarViewInterface.h"
+#include "kddockwidgets/views/TitleBarViewInterface.h"
 #include "View.h"
 
 namespace KDDockWidgets {

--- a/src/qtwidgets/views/MDIArea.cpp
+++ b/src/qtwidgets/views/MDIArea.cpp
@@ -13,7 +13,7 @@
 
 #include "private/View_p.h"
 
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 #include "kddockwidgets/views/DockWidgetViewInterface.h"
 #include "kddockwidgets/core/DockWidget.h"
 #include "kddockwidgets/core/MDILayout.h"

--- a/src/qtwidgets/views/MainWindow.cpp
+++ b/src/qtwidgets/views/MainWindow.cpp
@@ -18,7 +18,7 @@
 
 #include "MainWindow.h"
 #include "Config.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 #include "ViewWrapper.h"
 #include "kddockwidgets/core/DropArea.h"
 #include "kddockwidgets/core/MainWindow.h"

--- a/src/qtwidgets/views/TabBar.cpp
+++ b/src/qtwidgets/views/TabBar.cpp
@@ -18,7 +18,7 @@
 #include "private/Utils_p.h"
 #include "private/Logging_p.h"
 #include "Config.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 #include "kddockwidgets/private/DockRegistry.h"
 
 #include <QMouseEvent>

--- a/src/qtwidgets/views/TitleBar.cpp
+++ b/src/qtwidgets/views/TitleBar.cpp
@@ -17,7 +17,7 @@
 
 #include "private/Utils_p.h"
 #include "private/Logging_p.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 #include "kddockwidgets/private/DockRegistry.h"
 #include "qtwidgets/ViewFactory.h"
 

--- a/tests/core/tst_dockwidget.cpp
+++ b/tests/core/tst_dockwidget.cpp
@@ -15,7 +15,7 @@
 #include "kddockwidgets/core/Group.h"
 #include "kddockwidgets/core/Platform.h"
 #include "Action.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 #include "Config.h"
 
 using namespace KDDockWidgets::Core;

--- a/tests/core/tst_droparea.cpp
+++ b/tests/core/tst_droparea.cpp
@@ -14,7 +14,7 @@
 #include "core/Group.h"
 #include "Config.h"
 #include "kddockwidgets/core/DockWidget.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 #include "kddockwidgets/core/Platform.h"
 #include "Action.h"
 

--- a/tests/core/tst_floatingwindow.cpp
+++ b/tests/core/tst_floatingwindow.cpp
@@ -13,7 +13,7 @@
 #include "kddockwidgets/core/FloatingWindow.h"
 #include "kddockwidgets/core/Group.h"
 #include "kddockwidgets/core/DockWidget.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 #include "Config.h"
 
 using namespace KDDockWidgets::Core;

--- a/tests/core/tst_tabbar.cpp
+++ b/tests/core/tst_tabbar.cpp
@@ -14,7 +14,7 @@
 #include "kddockwidgets/core/Stack.h"
 #include "kddockwidgets/core/TabBar.h"
 #include "kddockwidgets/Config.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 
 using namespace KDDockWidgets;
 using namespace KDDockWidgets::Core;

--- a/tests/qtwidgets/tst_qtwidgets.cpp
+++ b/tests/qtwidgets/tst_qtwidgets.cpp
@@ -20,7 +20,7 @@
 #include "LayoutSaver.h"
 #include "LayoutSaver_p.h"
 #include "WindowBeingDragged_p.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 
 #include "multisplitter/Item_p.h"
 

--- a/tests/tst_docks.cpp
+++ b/tests/tst_docks.cpp
@@ -18,7 +18,7 @@
 #include "Position_p.h"
 #include "WindowBeingDragged_p.h"
 #include "multisplitter/Item_p.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 #include "Action.h"
 #include "kddockwidgets/core/MDILayout.h"
 #include "kddockwidgets/core/DropArea.h"

--- a/tests/tst_docks_main.h
+++ b/tests/tst_docks_main.h
@@ -10,6 +10,7 @@
 */
 
 #include "utils.h"
+
 #include "kddockwidgets/ViewFactory.h"
 #include "kddockwidgets/core/Window.h"
 #include "kddockwidgets/core/Platform.h"

--- a/tests/tst_docks_slow1.cpp
+++ b/tests/tst_docks_slow1.cpp
@@ -21,7 +21,7 @@
 #include "Position_p.h"
 #include "WindowBeingDragged_p.h"
 #include "multisplitter/Item_p.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 #include "Action.h"
 #include "kddockwidgets/core/MDILayout.h"
 #include "kddockwidgets/core/DropArea.h"

--- a/tests/tst_docks_slow2.cpp
+++ b/tests/tst_docks_slow2.cpp
@@ -21,7 +21,7 @@
 #include "Position_p.h"
 #include "WindowBeingDragged_p.h"
 #include "multisplitter/Item_p.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 #include "Action.h"
 #include "kddockwidgets/core/MDILayout.h"
 #include "kddockwidgets/core/DropArea.h"

--- a/tests/tst_docks_slow3.cpp
+++ b/tests/tst_docks_slow3.cpp
@@ -21,7 +21,7 @@
 #include "Position_p.h"
 #include "WindowBeingDragged_p.h"
 #include "multisplitter/Item_p.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 #include "Action.h"
 #include "kddockwidgets/core/MDILayout.h"
 #include "kddockwidgets/core/DropArea.h"

--- a/tests/tst_docks_slow4.cpp
+++ b/tests/tst_docks_slow4.cpp
@@ -21,7 +21,7 @@
 #include "Position_p.h"
 #include "WindowBeingDragged_p.h"
 #include "multisplitter/Item_p.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 #include "Action.h"
 #include "kddockwidgets/core/MDILayout.h"
 #include "kddockwidgets/core/DropArea.h"

--- a/tests/tst_docks_slow5.cpp
+++ b/tests/tst_docks_slow5.cpp
@@ -21,7 +21,7 @@
 #include "Position_p.h"
 #include "WindowBeingDragged_p.h"
 #include "multisplitter/Item_p.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 #include "Action.h"
 #include "kddockwidgets/core/MDILayout.h"
 #include "kddockwidgets/core/DropArea.h"

--- a/tests/tst_docks_slow6.cpp
+++ b/tests/tst_docks_slow6.cpp
@@ -21,7 +21,7 @@
 #include "Position_p.h"
 #include "WindowBeingDragged_p.h"
 #include "multisplitter/Item_p.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 #include "Action.h"
 #include "kddockwidgets/core/MDILayout.h"
 #include "kddockwidgets/core/DropArea.h"

--- a/tests/tst_docks_slow7.cpp
+++ b/tests/tst_docks_slow7.cpp
@@ -21,7 +21,7 @@
 #include "Position_p.h"
 #include "WindowBeingDragged_p.h"
 #include "multisplitter/Item_p.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 #include "Action.h"
 #include "kddockwidgets/core/MDILayout.h"
 #include "kddockwidgets/core/DropArea.h"

--- a/tests/tst_multisplitter.cpp
+++ b/tests/tst_multisplitter.cpp
@@ -15,7 +15,7 @@
 #include "kddockwidgets/core/Platform.h"
 
 #include "Config.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 
 #include <QtTest/QTest>
 #include <QScopedValueRollback>

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -11,7 +11,7 @@
 
 #include "utils.h"
 #include "Config.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 #include "NonQtCompat_p.h"
 #include "kddockwidgets/core/DropArea.h"
 #include "kddockwidgets/core/MainWindow.h"

--- a/tests/utils_qt.h
+++ b/tests/utils_qt.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include "utils.h"
-#include "kddockwidgets/ViewFactory.h"
+#include "kddockwidgets/core/ViewFactory.h"
 #include "kddockwidgets/core/MainWindow.h"
 #include "kddockwidgets/core/Window.h"
 #include "kddockwidgets/core/Platform.h"


### PR DESCRIPTION
This PR refactors and fixes some header includes to get `KDDockWidgets` building with branch `2.0` when included via CMake's `add_subdirectory` function from another project.

For context I have a project which includes `kddockwidgets` under a subdirectory as a git submodule  and then uses `add_subdirectory(dependencies/KDDockWidgets)` to include the library with the following options:

```cmake
set(KDDockWidgets_STATIC ON CACHE BOOL "Build static versions of the libraries" FORCE)
set(KDDockWidgets_QT6 ON CACHE BOOL "Build against Qt6 rather than Qt5" FORCE)
set(KDDockWidgets_FRONTENDS "qtquick" CACHE STRING "Build for QtQuick instead of QtWidgets" FORCE)
set(KDDockWidgets_EXAMPLES OFF CACHE BOOL "Build the examples" FORCE)
add_subdirectory(dependencies/KDDockWidgets)
```

It then links by adding `KDAB::kddockwidgets` to the `target_link_libraries` for the base project.

A quick GitHub search turned up various repos using this same submodule approach so I would guess this effects others as well:
- https://github.com/junjiexing/XingDBG/tree/777018a199c3c8f8398ae8e44740523ce54bcca1
- https://github.com/iwoithe/Molar/tree/c91bf366d5e4cb8324ccc8863b2674253028e13b
- https://github.com/GetPretzel/Pretzel/tree/b09592dd04ec881393dde9b9c736dde75857cbc5

I was getting a bunch of compile errors but the changes in this pr got things building for me. It is mostly just header fixes. I doubt I caught everything as it seems to depend on which headers your trying to include, but it should improve the situation.




