### PR TITLE
fix: rename IsExpicitlyHidden to IsExplicitlyHidden

### DIFF
--- a/src/core/View.h
+++ b/src/core/View.h
@@ -92,7 +92,7 @@ public:
     virtual QRect normalGeometry() const = 0;
     virtual void setGeometry(QRect) = 0;
     virtual bool isVisible() const = 0;
-    virtual bool isExpicitlyHidden() const = 0;
+    virtual bool isExplicitlyHidden() const = 0;
     virtual void setVisible(bool) = 0;
     virtual void move(int x, int y) = 0;
     virtual void setSize(int width, int height) = 0;

--- a/src/flutter/dart/lib/View_mixin.dart
+++ b/src/flutter/dart/lib/View_mixin.dart
@@ -140,7 +140,7 @@ class View_mixin {
 
   List<Widget> visibleChildWidgets() {
     return childWidgets.where((w) {
-      return !(w as PositionedWidget).kddwView.kddwView.isExpicitlyHidden();
+      return !(w as PositionedWidget).kddwView.kddwView.isExplicitlyHidden();
     }).toList();
   }
 

--- a/src/flutter/generated/KDDockWidgetsBindings/KDDockWidgetsBindings_exports.h
+++ b/src/flutter/generated/KDDockWidgetsBindings/KDDockWidgetsBindings_exports.h
@@ -13,7 +13,7 @@
 #include <QtCore/QtGlobal>
 
 #if defined(BUILDING_KDDockWidgetsBindings)
-#  define KDDockWidgetsBindings_EXPORT Q_DECL_EXPORT
+#define KDDockWidgetsBindings_EXPORT Q_DECL_EXPORT
 #else
-#  define KDDockWidgetsBindings_EXPORT Q_DECL_IMPORT
+#define KDDockWidgetsBindings_EXPORT Q_DECL_IMPORT
 #endif

--- a/src/flutter/generated/KDDockWidgetsBindings/dart/ffi/KDDWBindingsFlutter/Window_c.cpp
+++ b/src/flutter/generated/KDDockWidgetsBindings/dart/ffi/KDDWBindingsFlutter/Window_c.cpp
@@ -26,100 +26,380 @@ struct ValueWrapper
 };
 
 }
-namespace KDDockWidgetsBindings_wrappersNS {namespace KDDWBindingsFlutter {void Window_wrapper::destroy(){if (m_destroyCallback) {const void* thisPtr = this;
-m_destroyCallback(const_cast<void *>(thisPtr));} else {::KDDockWidgets::flutter::Window::destroy();}}void Window_wrapper::destroy_nocallback(){::KDDockWidgets::flutter::Window::destroy();}
-QRect Window_wrapper::frameGeometry()const{if (m_frameGeometryCallback) {const void* thisPtr = this;
-return *m_frameGeometryCallback(const_cast<void *>(thisPtr));} else {return ::KDDockWidgets::flutter::Window::frameGeometry();}}QRect Window_wrapper::frameGeometry_nocallback()const{return ::KDDockWidgets::flutter::Window::frameGeometry();}
-QPoint Window_wrapper::fromNativePixels(QPoint arg__1)const{if (m_fromNativePixelsCallback) {const void* thisPtr = this;
-return *m_fromNativePixelsCallback(const_cast<void *>(thisPtr),&arg__1);} else {return ::KDDockWidgets::flutter::Window::fromNativePixels(arg__1);}}QPoint Window_wrapper::fromNativePixels_nocallback(QPoint arg__1)const{return ::KDDockWidgets::flutter::Window::fromNativePixels(arg__1);}
-QRect Window_wrapper::geometry()const{if (m_geometryCallback) {const void* thisPtr = this;
-return *m_geometryCallback(const_cast<void *>(thisPtr));} else {return ::KDDockWidgets::flutter::Window::geometry();}}QRect Window_wrapper::geometry_nocallback()const{return ::KDDockWidgets::flutter::Window::geometry();}
-bool Window_wrapper::isActive()const{if (m_isActiveCallback) {const void* thisPtr = this;
-return m_isActiveCallback(const_cast<void *>(thisPtr));} else {return ::KDDockWidgets::flutter::Window::isActive();}}bool Window_wrapper::isActive_nocallback()const{return ::KDDockWidgets::flutter::Window::isActive();}
-bool Window_wrapper::isFullScreen()const{if (m_isFullScreenCallback) {const void* thisPtr = this;
-return m_isFullScreenCallback(const_cast<void *>(thisPtr));} else {return ::KDDockWidgets::flutter::Window::isFullScreen();}}bool Window_wrapper::isFullScreen_nocallback()const{return ::KDDockWidgets::flutter::Window::isFullScreen();}
-bool Window_wrapper::isVisible()const{if (m_isVisibleCallback) {const void* thisPtr = this;
-return m_isVisibleCallback(const_cast<void *>(thisPtr));} else {return ::KDDockWidgets::flutter::Window::isVisible();}}bool Window_wrapper::isVisible_nocallback()const{return ::KDDockWidgets::flutter::Window::isVisible();}
-QPoint Window_wrapper::mapFromGlobal(QPoint globalPos)const{if (m_mapFromGlobalCallback) {const void* thisPtr = this;
-return *m_mapFromGlobalCallback(const_cast<void *>(thisPtr),&globalPos);} else {return ::KDDockWidgets::flutter::Window::mapFromGlobal(globalPos);}}QPoint Window_wrapper::mapFromGlobal_nocallback(QPoint globalPos)const{return ::KDDockWidgets::flutter::Window::mapFromGlobal(globalPos);}
-QPoint Window_wrapper::mapToGlobal(QPoint localPos)const{if (m_mapToGlobalCallback) {const void* thisPtr = this;
-return *m_mapToGlobalCallback(const_cast<void *>(thisPtr),&localPos);} else {return ::KDDockWidgets::flutter::Window::mapToGlobal(localPos);}}QPoint Window_wrapper::mapToGlobal_nocallback(QPoint localPos)const{return ::KDDockWidgets::flutter::Window::mapToGlobal(localPos);}
-QSize Window_wrapper::maxSize()const{if (m_maxSizeCallback) {const void* thisPtr = this;
-return *m_maxSizeCallback(const_cast<void *>(thisPtr));} else {return ::KDDockWidgets::flutter::Window::maxSize();}}QSize Window_wrapper::maxSize_nocallback()const{return ::KDDockWidgets::flutter::Window::maxSize();}
-QSize Window_wrapper::minSize()const{if (m_minSizeCallback) {const void* thisPtr = this;
-return *m_minSizeCallback(const_cast<void *>(thisPtr));} else {return ::KDDockWidgets::flutter::Window::minSize();}}QSize Window_wrapper::minSize_nocallback()const{return ::KDDockWidgets::flutter::Window::minSize();}
-void Window_wrapper::resize(int width,int height){if (m_resizeCallback) {const void* thisPtr = this;
-m_resizeCallback(const_cast<void *>(thisPtr),width,height);} else {::KDDockWidgets::flutter::Window::resize(width,height);}}void Window_wrapper::resize_nocallback(int width,int height){::KDDockWidgets::flutter::Window::resize(width,height);}
-void Window_wrapper::setFramePosition(QPoint targetPos){if (m_setFramePositionCallback) {const void* thisPtr = this;
-m_setFramePositionCallback(const_cast<void *>(thisPtr),&targetPos);} else {::KDDockWidgets::flutter::Window::setFramePosition(targetPos);}}void Window_wrapper::setFramePosition_nocallback(QPoint targetPos){::KDDockWidgets::flutter::Window::setFramePosition(targetPos);}
-void Window_wrapper::setGeometry(QRect arg__1){if (m_setGeometryCallback) {const void* thisPtr = this;
-m_setGeometryCallback(const_cast<void *>(thisPtr),&arg__1);} else {::KDDockWidgets::flutter::Window::setGeometry(arg__1);}}void Window_wrapper::setGeometry_nocallback(QRect arg__1){::KDDockWidgets::flutter::Window::setGeometry(arg__1);}
-void Window_wrapper::setVisible(bool arg__1){if (m_setVisibleCallback) {const void* thisPtr = this;
-m_setVisibleCallback(const_cast<void *>(thisPtr),arg__1);} else {::KDDockWidgets::flutter::Window::setVisible(arg__1);}}void Window_wrapper::setVisible_nocallback(bool arg__1){::KDDockWidgets::flutter::Window::setVisible(arg__1);}
-bool Window_wrapper::supportsHonouringLayoutMinSize()const{if (m_supportsHonouringLayoutMinSizeCallback) {const void* thisPtr = this;
-return m_supportsHonouringLayoutMinSizeCallback(const_cast<void *>(thisPtr));} else {return ::KDDockWidgets::flutter::Window::supportsHonouringLayoutMinSize();}}bool Window_wrapper::supportsHonouringLayoutMinSize_nocallback()const{return ::KDDockWidgets::flutter::Window::supportsHonouringLayoutMinSize();}
-Window_wrapper::~Window_wrapper() {}
+namespace KDDockWidgetsBindings_wrappersNS {
+namespace KDDWBindingsFlutter {
+void Window_wrapper::destroy()
+{
+    if (m_destroyCallback) {
+        const void *thisPtr = this;
+        m_destroyCallback(const_cast<void *>(thisPtr));
+    } else {
+        ::KDDockWidgets::flutter::Window::destroy();
+    }
+}
+void Window_wrapper::destroy_nocallback()
+{
+    ::KDDockWidgets::flutter::Window::destroy();
+}
+QRect Window_wrapper::frameGeometry() const
+{
+    if (m_frameGeometryCallback) {
+        const void *thisPtr = this;
+        return *m_frameGeometryCallback(const_cast<void *>(thisPtr));
+    } else {
+        return ::KDDockWidgets::flutter::Window::frameGeometry();
+    }
+}
+QRect Window_wrapper::frameGeometry_nocallback() const
+{
+    return ::KDDockWidgets::flutter::Window::frameGeometry();
+}
+QPoint Window_wrapper::fromNativePixels(QPoint arg__1) const
+{
+    if (m_fromNativePixelsCallback) {
+        const void *thisPtr = this;
+        return *m_fromNativePixelsCallback(const_cast<void *>(thisPtr), &arg__1);
+    } else {
+        return ::KDDockWidgets::flutter::Window::fromNativePixels(arg__1);
+    }
+}
+QPoint Window_wrapper::fromNativePixels_nocallback(QPoint arg__1) const
+{
+    return ::KDDockWidgets::flutter::Window::fromNativePixels(arg__1);
+}
+QRect Window_wrapper::geometry() const
+{
+    if (m_geometryCallback) {
+        const void *thisPtr = this;
+        return *m_geometryCallback(const_cast<void *>(thisPtr));
+    } else {
+        return ::KDDockWidgets::flutter::Window::geometry();
+    }
+}
+QRect Window_wrapper::geometry_nocallback() const
+{
+    return ::KDDockWidgets::flutter::Window::geometry();
+}
+bool Window_wrapper::isActive() const
+{
+    if (m_isActiveCallback) {
+        const void *thisPtr = this;
+        return m_isActiveCallback(const_cast<void *>(thisPtr));
+    } else {
+        return ::KDDockWidgets::flutter::Window::isActive();
+    }
+}
+bool Window_wrapper::isActive_nocallback() const
+{
+    return ::KDDockWidgets::flutter::Window::isActive();
+}
+bool Window_wrapper::isFullScreen() const
+{
+    if (m_isFullScreenCallback) {
+        const void *thisPtr = this;
+        return m_isFullScreenCallback(const_cast<void *>(thisPtr));
+    } else {
+        return ::KDDockWidgets::flutter::Window::isFullScreen();
+    }
+}
+bool Window_wrapper::isFullScreen_nocallback() const
+{
+    return ::KDDockWidgets::flutter::Window::isFullScreen();
+}
+bool Window_wrapper::isVisible() const
+{
+    if (m_isVisibleCallback) {
+        const void *thisPtr = this;
+        return m_isVisibleCallback(const_cast<void *>(thisPtr));
+    } else {
+        return ::KDDockWidgets::flutter::Window::isVisible();
+    }
+}
+bool Window_wrapper::isVisible_nocallback() const
+{
+    return ::KDDockWidgets::flutter::Window::isVisible();
+}
+QPoint Window_wrapper::mapFromGlobal(QPoint globalPos) const
+{
+    if (m_mapFromGlobalCallback) {
+        const void *thisPtr = this;
+        return *m_mapFromGlobalCallback(const_cast<void *>(thisPtr), &globalPos);
+    } else {
+        return ::KDDockWidgets::flutter::Window::mapFromGlobal(globalPos);
+    }
+}
+QPoint Window_wrapper::mapFromGlobal_nocallback(QPoint globalPos) const
+{
+    return ::KDDockWidgets::flutter::Window::mapFromGlobal(globalPos);
+}
+QPoint Window_wrapper::mapToGlobal(QPoint localPos) const
+{
+    if (m_mapToGlobalCallback) {
+        const void *thisPtr = this;
+        return *m_mapToGlobalCallback(const_cast<void *>(thisPtr), &localPos);
+    } else {
+        return ::KDDockWidgets::flutter::Window::mapToGlobal(localPos);
+    }
+}
+QPoint Window_wrapper::mapToGlobal_nocallback(QPoint localPos) const
+{
+    return ::KDDockWidgets::flutter::Window::mapToGlobal(localPos);
+}
+QSize Window_wrapper::maxSize() const
+{
+    if (m_maxSizeCallback) {
+        const void *thisPtr = this;
+        return *m_maxSizeCallback(const_cast<void *>(thisPtr));
+    } else {
+        return ::KDDockWidgets::flutter::Window::maxSize();
+    }
+}
+QSize Window_wrapper::maxSize_nocallback() const
+{
+    return ::KDDockWidgets::flutter::Window::maxSize();
+}
+QSize Window_wrapper::minSize() const
+{
+    if (m_minSizeCallback) {
+        const void *thisPtr = this;
+        return *m_minSizeCallback(const_cast<void *>(thisPtr));
+    } else {
+        return ::KDDockWidgets::flutter::Window::minSize();
+    }
+}
+QSize Window_wrapper::minSize_nocallback() const
+{
+    return ::KDDockWidgets::flutter::Window::minSize();
+}
+void Window_wrapper::resize(int width, int height)
+{
+    if (m_resizeCallback) {
+        const void *thisPtr = this;
+        m_resizeCallback(const_cast<void *>(thisPtr), width, height);
+    } else {
+        ::KDDockWidgets::flutter::Window::resize(width, height);
+    }
+}
+void Window_wrapper::resize_nocallback(int width, int height)
+{
+    ::KDDockWidgets::flutter::Window::resize(width, height);
+}
+void Window_wrapper::setFramePosition(QPoint targetPos)
+{
+    if (m_setFramePositionCallback) {
+        const void *thisPtr = this;
+        m_setFramePositionCallback(const_cast<void *>(thisPtr), &targetPos);
+    } else {
+        ::KDDockWidgets::flutter::Window::setFramePosition(targetPos);
+    }
+}
+void Window_wrapper::setFramePosition_nocallback(QPoint targetPos)
+{
+    ::KDDockWidgets::flutter::Window::setFramePosition(targetPos);
+}
+void Window_wrapper::setGeometry(QRect arg__1)
+{
+    if (m_setGeometryCallback) {
+        const void *thisPtr = this;
+        m_setGeometryCallback(const_cast<void *>(thisPtr), &arg__1);
+    } else {
+        ::KDDockWidgets::flutter::Window::setGeometry(arg__1);
+    }
+}
+void Window_wrapper::setGeometry_nocallback(QRect arg__1)
+{
+    ::KDDockWidgets::flutter::Window::setGeometry(arg__1);
+}
+void Window_wrapper::setVisible(bool arg__1)
+{
+    if (m_setVisibleCallback) {
+        const void *thisPtr = this;
+        m_setVisibleCallback(const_cast<void *>(thisPtr), arg__1);
+    } else {
+        ::KDDockWidgets::flutter::Window::setVisible(arg__1);
+    }
+}
+void Window_wrapper::setVisible_nocallback(bool arg__1)
+{
+    ::KDDockWidgets::flutter::Window::setVisible(arg__1);
+}
+bool Window_wrapper::supportsHonouringLayoutMinSize() const
+{
+    if (m_supportsHonouringLayoutMinSizeCallback) {
+        const void *thisPtr = this;
+        return m_supportsHonouringLayoutMinSizeCallback(const_cast<void *>(thisPtr));
+    } else {
+        return ::KDDockWidgets::flutter::Window::supportsHonouringLayoutMinSize();
+    }
+}
+bool Window_wrapper::supportsHonouringLayoutMinSize_nocallback() const
+{
+    return ::KDDockWidgets::flutter::Window::supportsHonouringLayoutMinSize();
+}
+Window_wrapper::~Window_wrapper()
+{
+}
 
-}}static KDDockWidgets::flutter::Window* fromPtr(void *ptr)
-{return reinterpret_cast<KDDockWidgets::flutter::Window*>(ptr);}static KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper* fromWrapperPtr(void *ptr)
-{return reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(ptr);}extern "C" {
- void c_KDDockWidgets__flutter__Window_Finalizer(void *, void *cppObj, void *){delete reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper *>(cppObj);}//destroy()
-void c_KDDockWidgets__flutter__Window__destroy(void *thisObj){[&]{auto targetPtr = fromPtr(thisObj);auto wrapperPtr = dynamic_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(targetPtr);if (wrapperPtr) {    return wrapperPtr->destroy_nocallback();} else {    return targetPtr->destroy();}}();}
-//frameGeometry() const
-void* c_KDDockWidgets__flutter__Window__frameGeometry(void *thisObj){return new Dartagnan::ValueWrapper<QRect>{[&]{auto targetPtr = fromPtr(thisObj);auto wrapperPtr = dynamic_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(targetPtr);if (wrapperPtr) {    return wrapperPtr->frameGeometry_nocallback();} else {    return targetPtr->frameGeometry();}}()};}
-//fromNativePixels(QPoint arg__1) const
-void* c_KDDockWidgets__flutter__Window__fromNativePixels_QPoint(void *thisObj,void* arg__1_){assert(arg__1_);
-auto &arg__1 = *reinterpret_cast<QPoint *>(arg__1_);return new Dartagnan::ValueWrapper<QPoint>{[&]{auto targetPtr = fromPtr(thisObj);auto wrapperPtr = dynamic_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(targetPtr);if (wrapperPtr) {    return wrapperPtr->fromNativePixels_nocallback(arg__1);} else {    return targetPtr->fromNativePixels(arg__1);}}()};}
-//geometry() const
-void* c_KDDockWidgets__flutter__Window__geometry(void *thisObj){return new Dartagnan::ValueWrapper<QRect>{[&]{auto targetPtr = fromPtr(thisObj);auto wrapperPtr = dynamic_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(targetPtr);if (wrapperPtr) {    return wrapperPtr->geometry_nocallback();} else {    return targetPtr->geometry();}}()};}
-//isActive() const
-bool c_KDDockWidgets__flutter__Window__isActive(void *thisObj){return [&]{auto targetPtr = fromPtr(thisObj);auto wrapperPtr = dynamic_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(targetPtr);if (wrapperPtr) {    return wrapperPtr->isActive_nocallback();} else {    return targetPtr->isActive();}}();}
-//isFullScreen() const
-bool c_KDDockWidgets__flutter__Window__isFullScreen(void *thisObj){return [&]{auto targetPtr = fromPtr(thisObj);auto wrapperPtr = dynamic_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(targetPtr);if (wrapperPtr) {    return wrapperPtr->isFullScreen_nocallback();} else {    return targetPtr->isFullScreen();}}();}
-//isVisible() const
-bool c_KDDockWidgets__flutter__Window__isVisible(void *thisObj){return [&]{auto targetPtr = fromPtr(thisObj);auto wrapperPtr = dynamic_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(targetPtr);if (wrapperPtr) {    return wrapperPtr->isVisible_nocallback();} else {    return targetPtr->isVisible();}}();}
-//mapFromGlobal(QPoint globalPos) const
-void* c_KDDockWidgets__flutter__Window__mapFromGlobal_QPoint(void *thisObj,void* globalPos_){assert(globalPos_);
-auto &globalPos = *reinterpret_cast<QPoint *>(globalPos_);return new Dartagnan::ValueWrapper<QPoint>{[&]{auto targetPtr = fromPtr(thisObj);auto wrapperPtr = dynamic_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(targetPtr);if (wrapperPtr) {    return wrapperPtr->mapFromGlobal_nocallback(globalPos);} else {    return targetPtr->mapFromGlobal(globalPos);}}()};}
-//mapToGlobal(QPoint localPos) const
-void* c_KDDockWidgets__flutter__Window__mapToGlobal_QPoint(void *thisObj,void* localPos_){assert(localPos_);
-auto &localPos = *reinterpret_cast<QPoint *>(localPos_);return new Dartagnan::ValueWrapper<QPoint>{[&]{auto targetPtr = fromPtr(thisObj);auto wrapperPtr = dynamic_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(targetPtr);if (wrapperPtr) {    return wrapperPtr->mapToGlobal_nocallback(localPos);} else {    return targetPtr->mapToGlobal(localPos);}}()};}
-//maxSize() const
-void* c_KDDockWidgets__flutter__Window__maxSize(void *thisObj){return new Dartagnan::ValueWrapper<QSize>{[&]{auto targetPtr = fromPtr(thisObj);auto wrapperPtr = dynamic_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(targetPtr);if (wrapperPtr) {    return wrapperPtr->maxSize_nocallback();} else {    return targetPtr->maxSize();}}()};}
-//minSize() const
-void* c_KDDockWidgets__flutter__Window__minSize(void *thisObj){return new Dartagnan::ValueWrapper<QSize>{[&]{auto targetPtr = fromPtr(thisObj);auto wrapperPtr = dynamic_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(targetPtr);if (wrapperPtr) {    return wrapperPtr->minSize_nocallback();} else {    return targetPtr->minSize();}}()};}
-//resize(int width, int height)
-void c_KDDockWidgets__flutter__Window__resize_int_int(void *thisObj,int width,int height){[&]{auto targetPtr = fromPtr(thisObj);auto wrapperPtr = dynamic_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(targetPtr);if (wrapperPtr) {    return wrapperPtr->resize_nocallback(width,height);} else {    return targetPtr->resize(width,height);}}();}
-//setFramePosition(QPoint targetPos)
-void c_KDDockWidgets__flutter__Window__setFramePosition_QPoint(void *thisObj,void* targetPos_){assert(targetPos_);
-auto &targetPos = *reinterpret_cast<QPoint *>(targetPos_);[&]{auto targetPtr = fromPtr(thisObj);auto wrapperPtr = dynamic_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(targetPtr);if (wrapperPtr) {    return wrapperPtr->setFramePosition_nocallback(targetPos);} else {    return targetPtr->setFramePosition(targetPos);}}();}
-//setGeometry(QRect arg__1)
-void c_KDDockWidgets__flutter__Window__setGeometry_QRect(void *thisObj,void* arg__1_){assert(arg__1_);
-auto &arg__1 = *reinterpret_cast<QRect *>(arg__1_);[&]{auto targetPtr = fromPtr(thisObj);auto wrapperPtr = dynamic_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(targetPtr);if (wrapperPtr) {    return wrapperPtr->setGeometry_nocallback(arg__1);} else {    return targetPtr->setGeometry(arg__1);}}();}
-//setVisible(bool arg__1)
-void c_KDDockWidgets__flutter__Window__setVisible_bool(void *thisObj,bool arg__1){[&]{auto targetPtr = fromPtr(thisObj);auto wrapperPtr = dynamic_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(targetPtr);if (wrapperPtr) {    return wrapperPtr->setVisible_nocallback(arg__1);} else {    return targetPtr->setVisible(arg__1);}}();}
-//supportsHonouringLayoutMinSize() const
-bool c_KDDockWidgets__flutter__Window__supportsHonouringLayoutMinSize(void *thisObj){return [&]{auto targetPtr = fromPtr(thisObj);auto wrapperPtr = dynamic_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(targetPtr);if (wrapperPtr) {    return wrapperPtr->supportsHonouringLayoutMinSize_nocallback();} else {    return targetPtr->supportsHonouringLayoutMinSize();}}();}
+}
+}
+static KDDockWidgets::flutter::Window *fromPtr(void *ptr)
+{
+    return reinterpret_cast<KDDockWidgets::flutter::Window *>(ptr);
+}
+static KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper *fromWrapperPtr(void *ptr)
+{
+    return reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper *>(ptr);
+}
+extern "C" {
+void c_KDDockWidgets__flutter__Window_Finalizer(void *, void *cppObj, void *)
+{
+    delete reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper *>(cppObj);
+} // destroy()
+void c_KDDockWidgets__flutter__Window__destroy(void *thisObj)
+{
+    [&] {auto targetPtr = fromPtr(thisObj);auto wrapperPtr = dynamic_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(targetPtr);if (wrapperPtr) {    return wrapperPtr->destroy_nocallback();} else {    return targetPtr->destroy();} }();
+}
+// frameGeometry() const
+void *c_KDDockWidgets__flutter__Window__frameGeometry(void *thisObj)
+{
+    return new Dartagnan::ValueWrapper<QRect> { [&] {auto targetPtr = fromPtr(thisObj);auto wrapperPtr = dynamic_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(targetPtr);if (wrapperPtr) {    return wrapperPtr->frameGeometry_nocallback();} else {    return targetPtr->frameGeometry();} }() };
+}
+// fromNativePixels(QPoint arg__1) const
+void *c_KDDockWidgets__flutter__Window__fromNativePixels_QPoint(void *thisObj, void *arg__1_)
+{
+    assert(arg__1_);
+    auto &arg__1 = *reinterpret_cast<QPoint *>(arg__1_);
+    return new Dartagnan::ValueWrapper<QPoint> { [&] {auto targetPtr = fromPtr(thisObj);auto wrapperPtr = dynamic_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(targetPtr);if (wrapperPtr) {    return wrapperPtr->fromNativePixels_nocallback(arg__1);} else {    return targetPtr->fromNativePixels(arg__1);} }() };
+}
+// geometry() const
+void *c_KDDockWidgets__flutter__Window__geometry(void *thisObj)
+{
+    return new Dartagnan::ValueWrapper<QRect> { [&] {auto targetPtr = fromPtr(thisObj);auto wrapperPtr = dynamic_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(targetPtr);if (wrapperPtr) {    return wrapperPtr->geometry_nocallback();} else {    return targetPtr->geometry();} }() };
+}
+// isActive() const
+bool c_KDDockWidgets__flutter__Window__isActive(void *thisObj)
+{
+    return [&] {auto targetPtr = fromPtr(thisObj);auto wrapperPtr = dynamic_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(targetPtr);if (wrapperPtr) {    return wrapperPtr->isActive_nocallback();} else {    return targetPtr->isActive();} }();
+}
+// isFullScreen() const
+bool c_KDDockWidgets__flutter__Window__isFullScreen(void *thisObj)
+{
+    return [&] {auto targetPtr = fromPtr(thisObj);auto wrapperPtr = dynamic_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(targetPtr);if (wrapperPtr) {    return wrapperPtr->isFullScreen_nocallback();} else {    return targetPtr->isFullScreen();} }();
+}
+// isVisible() const
+bool c_KDDockWidgets__flutter__Window__isVisible(void *thisObj)
+{
+    return [&] {auto targetPtr = fromPtr(thisObj);auto wrapperPtr = dynamic_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(targetPtr);if (wrapperPtr) {    return wrapperPtr->isVisible_nocallback();} else {    return targetPtr->isVisible();} }();
+}
+// mapFromGlobal(QPoint globalPos) const
+void *c_KDDockWidgets__flutter__Window__mapFromGlobal_QPoint(void *thisObj, void *globalPos_)
+{
+    assert(globalPos_);
+    auto &globalPos = *reinterpret_cast<QPoint *>(globalPos_);
+    return new Dartagnan::ValueWrapper<QPoint> { [&] {auto targetPtr = fromPtr(thisObj);auto wrapperPtr = dynamic_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(targetPtr);if (wrapperPtr) {    return wrapperPtr->mapFromGlobal_nocallback(globalPos);} else {    return targetPtr->mapFromGlobal(globalPos);} }() };
+}
+// mapToGlobal(QPoint localPos) const
+void *c_KDDockWidgets__flutter__Window__mapToGlobal_QPoint(void *thisObj, void *localPos_)
+{
+    assert(localPos_);
+    auto &localPos = *reinterpret_cast<QPoint *>(localPos_);
+    return new Dartagnan::ValueWrapper<QPoint> { [&] {auto targetPtr = fromPtr(thisObj);auto wrapperPtr = dynamic_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(targetPtr);if (wrapperPtr) {    return wrapperPtr->mapToGlobal_nocallback(localPos);} else {    return targetPtr->mapToGlobal(localPos);} }() };
+}
+// maxSize() const
+void *c_KDDockWidgets__flutter__Window__maxSize(void *thisObj)
+{
+    return new Dartagnan::ValueWrapper<QSize> { [&] {auto targetPtr = fromPtr(thisObj);auto wrapperPtr = dynamic_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(targetPtr);if (wrapperPtr) {    return wrapperPtr->maxSize_nocallback();} else {    return targetPtr->maxSize();} }() };
+}
+// minSize() const
+void *c_KDDockWidgets__flutter__Window__minSize(void *thisObj)
+{
+    return new Dartagnan::ValueWrapper<QSize> { [&] {auto targetPtr = fromPtr(thisObj);auto wrapperPtr = dynamic_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(targetPtr);if (wrapperPtr) {    return wrapperPtr->minSize_nocallback();} else {    return targetPtr->minSize();} }() };
+}
+// resize(int width, int height)
+void c_KDDockWidgets__flutter__Window__resize_int_int(void *thisObj, int width, int height)
+{
+    [&] {auto targetPtr = fromPtr(thisObj);auto wrapperPtr = dynamic_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(targetPtr);if (wrapperPtr) {    return wrapperPtr->resize_nocallback(width,height);} else {    return targetPtr->resize(width,height);} }();
+}
+// setFramePosition(QPoint targetPos)
+void c_KDDockWidgets__flutter__Window__setFramePosition_QPoint(void *thisObj, void *targetPos_)
+{
+    assert(targetPos_);
+    auto &targetPos = *reinterpret_cast<QPoint *>(targetPos_);
+    [&] {auto targetPtr = fromPtr(thisObj);auto wrapperPtr = dynamic_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(targetPtr);if (wrapperPtr) {    return wrapperPtr->setFramePosition_nocallback(targetPos);} else {    return targetPtr->setFramePosition(targetPos);} }();
+}
+// setGeometry(QRect arg__1)
+void c_KDDockWidgets__flutter__Window__setGeometry_QRect(void *thisObj, void *arg__1_)
+{
+    assert(arg__1_);
+    auto &arg__1 = *reinterpret_cast<QRect *>(arg__1_);
+    [&] {auto targetPtr = fromPtr(thisObj);auto wrapperPtr = dynamic_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(targetPtr);if (wrapperPtr) {    return wrapperPtr->setGeometry_nocallback(arg__1);} else {    return targetPtr->setGeometry(arg__1);} }();
+}
+// setVisible(bool arg__1)
+void c_KDDockWidgets__flutter__Window__setVisible_bool(void *thisObj, bool arg__1)
+{
+    [&] {auto targetPtr = fromPtr(thisObj);auto wrapperPtr = dynamic_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(targetPtr);if (wrapperPtr) {    return wrapperPtr->setVisible_nocallback(arg__1);} else {    return targetPtr->setVisible(arg__1);} }();
+}
+// supportsHonouringLayoutMinSize() const
+bool c_KDDockWidgets__flutter__Window__supportsHonouringLayoutMinSize(void *thisObj)
+{
+    return [&] {auto targetPtr = fromPtr(thisObj);auto wrapperPtr = dynamic_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper*>(targetPtr);if (wrapperPtr) {    return wrapperPtr->supportsHonouringLayoutMinSize_nocallback();} else {    return targetPtr->supportsHonouringLayoutMinSize();} }();
+}
 void c_KDDockWidgets__flutter__Window__destructor(void *thisObj)
 {
-delete fromPtr(thisObj);}
-void c_KDDockWidgets__flutter__Window__registerVirtualMethodCallback(void *ptr, void *callback, int methodId){auto wrapper = fromWrapperPtr(ptr);
-switch (methodId) {
-case 586:
-wrapper->m_destroyCallback = reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper::Callback_destroy>(callback);break;case 587:
-wrapper->m_frameGeometryCallback = reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper::Callback_frameGeometry>(callback);break;case 588:
-wrapper->m_fromNativePixelsCallback = reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper::Callback_fromNativePixels>(callback);break;case 589:
-wrapper->m_geometryCallback = reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper::Callback_geometry>(callback);break;case 591:
-wrapper->m_isActiveCallback = reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper::Callback_isActive>(callback);break;case 592:
-wrapper->m_isFullScreenCallback = reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper::Callback_isFullScreen>(callback);break;case 593:
-wrapper->m_isVisibleCallback = reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper::Callback_isVisible>(callback);break;case 594:
-wrapper->m_mapFromGlobalCallback = reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper::Callback_mapFromGlobal>(callback);break;case 595:
-wrapper->m_mapToGlobalCallback = reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper::Callback_mapToGlobal>(callback);break;case 596:
-wrapper->m_maxSizeCallback = reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper::Callback_maxSize>(callback);break;case 597:
-wrapper->m_minSizeCallback = reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper::Callback_minSize>(callback);break;case 598:
-wrapper->m_resizeCallback = reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper::Callback_resize>(callback);break;case 599:
-wrapper->m_setFramePositionCallback = reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper::Callback_setFramePosition>(callback);break;case 600:
-wrapper->m_setGeometryCallback = reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper::Callback_setGeometry>(callback);break;case 601:
-wrapper->m_setVisibleCallback = reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper::Callback_setVisible>(callback);break;case 602:
-wrapper->m_supportsHonouringLayoutMinSizeCallback = reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper::Callback_supportsHonouringLayoutMinSize>(callback);break;}
-}}
+    delete fromPtr(thisObj);
+}
+void c_KDDockWidgets__flutter__Window__registerVirtualMethodCallback(void *ptr, void *callback, int methodId)
+{
+    auto wrapper = fromWrapperPtr(ptr);
+    switch (methodId) {
+    case 586:
+        wrapper->m_destroyCallback = reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper::Callback_destroy>(callback);
+        break;
+    case 587:
+        wrapper->m_frameGeometryCallback = reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper::Callback_frameGeometry>(callback);
+        break;
+    case 588:
+        wrapper->m_fromNativePixelsCallback = reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper::Callback_fromNativePixels>(callback);
+        break;
+    case 589:
+        wrapper->m_geometryCallback = reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper::Callback_geometry>(callback);
+        break;
+    case 591:
+        wrapper->m_isActiveCallback = reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper::Callback_isActive>(callback);
+        break;
+    case 592:
+        wrapper->m_isFullScreenCallback = reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper::Callback_isFullScreen>(callback);
+        break;
+    case 593:
+        wrapper->m_isVisibleCallback = reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper::Callback_isVisible>(callback);
+        break;
+    case 594:
+        wrapper->m_mapFromGlobalCallback = reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper::Callback_mapFromGlobal>(callback);
+        break;
+    case 595:
+        wrapper->m_mapToGlobalCallback = reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper::Callback_mapToGlobal>(callback);
+        break;
+    case 596:
+        wrapper->m_maxSizeCallback = reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper::Callback_maxSize>(callback);
+        break;
+    case 597:
+        wrapper->m_minSizeCallback = reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper::Callback_minSize>(callback);
+        break;
+    case 598:
+        wrapper->m_resizeCallback = reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper::Callback_resize>(callback);
+        break;
+    case 599:
+        wrapper->m_setFramePositionCallback = reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper::Callback_setFramePosition>(callback);
+        break;
+    case 600:
+        wrapper->m_setGeometryCallback = reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper::Callback_setGeometry>(callback);
+        break;
+    case 601:
+        wrapper->m_setVisibleCallback = reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper::Callback_setVisible>(callback);
+        break;
+    case 602:
+        wrapper->m_supportsHonouringLayoutMinSizeCallback = reinterpret_cast<KDDockWidgetsBindings_wrappersNS::KDDWBindingsFlutter::Window_wrapper::Callback_supportsHonouringLayoutMinSize>(callback);
+        break;
+    }
+}
+}

--- a/src/flutter/generated/KDDockWidgetsBindings/dart/ffi/KDDWBindingsFlutter/Window_c.h
+++ b/src/flutter/generated/KDDockWidgetsBindings/dart/ffi/KDDWBindingsFlutter/Window_c.h
@@ -14,19 +14,88 @@
 #include <qpoint.h>
 #include <qsize.h>
 
-namespace KDDockWidgetsBindings_wrappersNS {namespace KDDWBindingsFlutter {class Window_wrapper : public ::KDDockWidgets::flutter::Window {public:
-~Window_wrapper();virtual void destroy();virtual void destroy_nocallback();virtual QRect frameGeometry()const;virtual QRect frameGeometry_nocallback()const;virtual QPoint fromNativePixels(QPoint arg__1)const;virtual QPoint fromNativePixels_nocallback(QPoint arg__1)const;virtual QRect geometry()const;virtual QRect geometry_nocallback()const;virtual bool isActive()const;virtual bool isActive_nocallback()const;virtual bool isFullScreen()const;virtual bool isFullScreen_nocallback()const;virtual bool isVisible()const;virtual bool isVisible_nocallback()const;virtual QPoint mapFromGlobal(QPoint globalPos)const;virtual QPoint mapFromGlobal_nocallback(QPoint globalPos)const;virtual QPoint mapToGlobal(QPoint localPos)const;virtual QPoint mapToGlobal_nocallback(QPoint localPos)const;virtual QSize maxSize()const;virtual QSize maxSize_nocallback()const;virtual QSize minSize()const;virtual QSize minSize_nocallback()const;virtual void resize(int width,int height);virtual void resize_nocallback(int width,int height);virtual void setFramePosition(QPoint targetPos);virtual void setFramePosition_nocallback(QPoint targetPos);virtual void setGeometry(QRect arg__1);virtual void setGeometry_nocallback(QRect arg__1);virtual void setVisible(bool arg__1);virtual void setVisible_nocallback(bool arg__1);virtual bool supportsHonouringLayoutMinSize()const;virtual bool supportsHonouringLayoutMinSize_nocallback()const;typedef void (*Callback_destroy)(void *);Callback_destroy m_destroyCallback = nullptr;typedef QRect* (*Callback_frameGeometry)(void *);Callback_frameGeometry m_frameGeometryCallback = nullptr;typedef QPoint* (*Callback_fromNativePixels)(void *,QPoint* arg__1);Callback_fromNativePixels m_fromNativePixelsCallback = nullptr;typedef QRect* (*Callback_geometry)(void *);Callback_geometry m_geometryCallback = nullptr;typedef bool (*Callback_isActive)(void *);Callback_isActive m_isActiveCallback = nullptr;typedef bool (*Callback_isFullScreen)(void *);Callback_isFullScreen m_isFullScreenCallback = nullptr;typedef bool (*Callback_isVisible)(void *);Callback_isVisible m_isVisibleCallback = nullptr;typedef QPoint* (*Callback_mapFromGlobal)(void *,QPoint* globalPos);Callback_mapFromGlobal m_mapFromGlobalCallback = nullptr;typedef QPoint* (*Callback_mapToGlobal)(void *,QPoint* localPos);Callback_mapToGlobal m_mapToGlobalCallback = nullptr;typedef QSize* (*Callback_maxSize)(void *);Callback_maxSize m_maxSizeCallback = nullptr;typedef QSize* (*Callback_minSize)(void *);Callback_minSize m_minSizeCallback = nullptr;typedef void (*Callback_resize)(void *,int width,int height);Callback_resize m_resizeCallback = nullptr;typedef void (*Callback_setFramePosition)(void *,QPoint* targetPos);Callback_setFramePosition m_setFramePositionCallback = nullptr;typedef void (*Callback_setGeometry)(void *,QRect* arg__1);Callback_setGeometry m_setGeometryCallback = nullptr;typedef void (*Callback_setVisible)(void *,bool arg__1);Callback_setVisible m_setVisibleCallback = nullptr;typedef bool (*Callback_supportsHonouringLayoutMinSize)(void *);Callback_supportsHonouringLayoutMinSize m_supportsHonouringLayoutMinSizeCallback = nullptr;
-
+namespace KDDockWidgetsBindings_wrappersNS {
+namespace KDDWBindingsFlutter {
+class Window_wrapper : public ::KDDockWidgets::flutter::Window
+{
+public:
+    ~Window_wrapper();
+    virtual void destroy();
+    virtual void destroy_nocallback();
+    virtual QRect frameGeometry() const;
+    virtual QRect frameGeometry_nocallback() const;
+    virtual QPoint fromNativePixels(QPoint arg__1) const;
+    virtual QPoint fromNativePixels_nocallback(QPoint arg__1) const;
+    virtual QRect geometry() const;
+    virtual QRect geometry_nocallback() const;
+    virtual bool isActive() const;
+    virtual bool isActive_nocallback() const;
+    virtual bool isFullScreen() const;
+    virtual bool isFullScreen_nocallback() const;
+    virtual bool isVisible() const;
+    virtual bool isVisible_nocallback() const;
+    virtual QPoint mapFromGlobal(QPoint globalPos) const;
+    virtual QPoint mapFromGlobal_nocallback(QPoint globalPos) const;
+    virtual QPoint mapToGlobal(QPoint localPos) const;
+    virtual QPoint mapToGlobal_nocallback(QPoint localPos) const;
+    virtual QSize maxSize() const;
+    virtual QSize maxSize_nocallback() const;
+    virtual QSize minSize() const;
+    virtual QSize minSize_nocallback() const;
+    virtual void resize(int width, int height);
+    virtual void resize_nocallback(int width, int height);
+    virtual void setFramePosition(QPoint targetPos);
+    virtual void setFramePosition_nocallback(QPoint targetPos);
+    virtual void setGeometry(QRect arg__1);
+    virtual void setGeometry_nocallback(QRect arg__1);
+    virtual void setVisible(bool arg__1);
+    virtual void setVisible_nocallback(bool arg__1);
+    virtual bool supportsHonouringLayoutMinSize() const;
+    virtual bool supportsHonouringLayoutMinSize_nocallback() const;
+    typedef void (*Callback_destroy)(void *);
+    Callback_destroy m_destroyCallback = nullptr;
+    typedef QRect *(*Callback_frameGeometry)(void *);
+    Callback_frameGeometry m_frameGeometryCallback = nullptr;
+    typedef QPoint *(*Callback_fromNativePixels)(void *, QPoint *arg__1);
+    Callback_fromNativePixels m_fromNativePixelsCallback = nullptr;
+    typedef QRect *(*Callback_geometry)(void *);
+    Callback_geometry m_geometryCallback = nullptr;
+    typedef bool (*Callback_isActive)(void *);
+    Callback_isActive m_isActiveCallback = nullptr;
+    typedef bool (*Callback_isFullScreen)(void *);
+    Callback_isFullScreen m_isFullScreenCallback = nullptr;
+    typedef bool (*Callback_isVisible)(void *);
+    Callback_isVisible m_isVisibleCallback = nullptr;
+    typedef QPoint *(*Callback_mapFromGlobal)(void *, QPoint *globalPos);
+    Callback_mapFromGlobal m_mapFromGlobalCallback = nullptr;
+    typedef QPoint *(*Callback_mapToGlobal)(void *, QPoint *localPos);
+    Callback_mapToGlobal m_mapToGlobalCallback = nullptr;
+    typedef QSize *(*Callback_maxSize)(void *);
+    Callback_maxSize m_maxSizeCallback = nullptr;
+    typedef QSize *(*Callback_minSize)(void *);
+    Callback_minSize m_minSizeCallback = nullptr;
+    typedef void (*Callback_resize)(void *, int width, int height);
+    Callback_resize m_resizeCallback = nullptr;
+    typedef void (*Callback_setFramePosition)(void *, QPoint *targetPos);
+    Callback_setFramePosition m_setFramePositionCallback = nullptr;
+    typedef void (*Callback_setGeometry)(void *, QRect *arg__1);
+    Callback_setGeometry m_setGeometryCallback = nullptr;
+    typedef void (*Callback_setVisible)(void *, bool arg__1);
+    Callback_setVisible m_setVisibleCallback = nullptr;
+    typedef bool (*Callback_supportsHonouringLayoutMinSize)(void *);
+    Callback_supportsHonouringLayoutMinSize m_supportsHonouringLayoutMinSizeCallback = nullptr;
 };
-}}extern "C" {
+}
+}
+extern "C" {
 // KDDockWidgets::flutter::Window::destroy()
 KDDockWidgetsBindings_EXPORT void c_KDDockWidgets__flutter__Window__destroy(void *thisObj);
 // KDDockWidgets::flutter::Window::frameGeometry() const
-KDDockWidgetsBindings_EXPORT void* c_KDDockWidgets__flutter__Window__frameGeometry(void *thisObj);
+KDDockWidgetsBindings_EXPORT void *c_KDDockWidgets__flutter__Window__frameGeometry(void *thisObj);
 // KDDockWidgets::flutter::Window::fromNativePixels(QPoint arg__1) const
-KDDockWidgetsBindings_EXPORT void* c_KDDockWidgets__flutter__Window__fromNativePixels_QPoint(void *thisObj,void* arg__1_);
+KDDockWidgetsBindings_EXPORT void *c_KDDockWidgets__flutter__Window__fromNativePixels_QPoint(void *thisObj, void *arg__1_);
 // KDDockWidgets::flutter::Window::geometry() const
-KDDockWidgetsBindings_EXPORT void* c_KDDockWidgets__flutter__Window__geometry(void *thisObj);
+KDDockWidgetsBindings_EXPORT void *c_KDDockWidgets__flutter__Window__geometry(void *thisObj);
 // KDDockWidgets::flutter::Window::isActive() const
 KDDockWidgetsBindings_EXPORT bool c_KDDockWidgets__flutter__Window__isActive(void *thisObj);
 // KDDockWidgets::flutter::Window::isFullScreen() const
@@ -34,22 +103,24 @@ KDDockWidgetsBindings_EXPORT bool c_KDDockWidgets__flutter__Window__isFullScreen
 // KDDockWidgets::flutter::Window::isVisible() const
 KDDockWidgetsBindings_EXPORT bool c_KDDockWidgets__flutter__Window__isVisible(void *thisObj);
 // KDDockWidgets::flutter::Window::mapFromGlobal(QPoint globalPos) const
-KDDockWidgetsBindings_EXPORT void* c_KDDockWidgets__flutter__Window__mapFromGlobal_QPoint(void *thisObj,void* globalPos_);
+KDDockWidgetsBindings_EXPORT void *c_KDDockWidgets__flutter__Window__mapFromGlobal_QPoint(void *thisObj, void *globalPos_);
 // KDDockWidgets::flutter::Window::mapToGlobal(QPoint localPos) const
-KDDockWidgetsBindings_EXPORT void* c_KDDockWidgets__flutter__Window__mapToGlobal_QPoint(void *thisObj,void* localPos_);
+KDDockWidgetsBindings_EXPORT void *c_KDDockWidgets__flutter__Window__mapToGlobal_QPoint(void *thisObj, void *localPos_);
 // KDDockWidgets::flutter::Window::maxSize() const
-KDDockWidgetsBindings_EXPORT void* c_KDDockWidgets__flutter__Window__maxSize(void *thisObj);
+KDDockWidgetsBindings_EXPORT void *c_KDDockWidgets__flutter__Window__maxSize(void *thisObj);
 // KDDockWidgets::flutter::Window::minSize() const
-KDDockWidgetsBindings_EXPORT void* c_KDDockWidgets__flutter__Window__minSize(void *thisObj);
+KDDockWidgetsBindings_EXPORT void *c_KDDockWidgets__flutter__Window__minSize(void *thisObj);
 // KDDockWidgets::flutter::Window::resize(int width, int height)
-KDDockWidgetsBindings_EXPORT void c_KDDockWidgets__flutter__Window__resize_int_int(void *thisObj,int width,int height);
+KDDockWidgetsBindings_EXPORT void c_KDDockWidgets__flutter__Window__resize_int_int(void *thisObj, int width, int height);
 // KDDockWidgets::flutter::Window::setFramePosition(QPoint targetPos)
-KDDockWidgetsBindings_EXPORT void c_KDDockWidgets__flutter__Window__setFramePosition_QPoint(void *thisObj,void* targetPos_);
+KDDockWidgetsBindings_EXPORT void c_KDDockWidgets__flutter__Window__setFramePosition_QPoint(void *thisObj, void *targetPos_);
 // KDDockWidgets::flutter::Window::setGeometry(QRect arg__1)
-KDDockWidgetsBindings_EXPORT void c_KDDockWidgets__flutter__Window__setGeometry_QRect(void *thisObj,void* arg__1_);
+KDDockWidgetsBindings_EXPORT void c_KDDockWidgets__flutter__Window__setGeometry_QRect(void *thisObj, void *arg__1_);
 // KDDockWidgets::flutter::Window::setVisible(bool arg__1)
-KDDockWidgetsBindings_EXPORT void c_KDDockWidgets__flutter__Window__setVisible_bool(void *thisObj,bool arg__1);
+KDDockWidgetsBindings_EXPORT void c_KDDockWidgets__flutter__Window__setVisible_bool(void *thisObj, bool arg__1);
 // KDDockWidgets::flutter::Window::supportsHonouringLayoutMinSize() const
 KDDockWidgetsBindings_EXPORT bool c_KDDockWidgets__flutter__Window__supportsHonouringLayoutMinSize(void *thisObj);
 KDDockWidgetsBindings_EXPORT void c_KDDockWidgets__flutter__Window__destructor(void *thisObj);
-KDDockWidgetsBindings_EXPORT void c_KDDockWidgets__flutter__Window__registerVirtualMethodCallback(void *ptr, void *callback, int methodId);KDDockWidgetsBindings_EXPORT  void c_KDDockWidgets__flutter__Window_Finalizer(void *, void *cppObj, void *);}
+KDDockWidgetsBindings_EXPORT void c_KDDockWidgets__flutter__Window__registerVirtualMethodCallback(void *ptr, void *callback, int methodId);
+KDDockWidgetsBindings_EXPORT void c_KDDockWidgets__flutter__Window_Finalizer(void *, void *cppObj, void *);
+}

--- a/src/flutter/generated/KDDockWidgetsBindings/dart/lib/src/DockRegistry.dart
+++ b/src/flutter/generated/KDDockWidgetsBindings/dart/lib/src/DockRegistry.dart
@@ -313,14 +313,14 @@ class DockRegistry extends QObject {
 
   String cFunctionSymbolName(int methodId) {
     switch (methodId) {
-      
+
     }
     return super.cFunctionSymbolName(methodId);
   }
 
   static String methodNameFromId(int methodId) {
     switch (methodId) {
-      
+
     }
     throw Error();
   }

--- a/src/flutter/generated/KDDockWidgetsBindings/dart/lib/src/QObject.dart
+++ b/src/flutter/generated/KDDockWidgetsBindings/dart/lib/src/QObject.dart
@@ -301,14 +301,14 @@ class QObject {
 
   String cFunctionSymbolName(int methodId) {
     switch (methodId) {
-      
+
     }
     return "";
   }
 
   static String methodNameFromId(int methodId) {
     switch (methodId) {
-      
+
     }
     throw Error();
   }

--- a/src/flutter/views/View.cpp
+++ b/src/flutter/views/View.cpp
@@ -87,7 +87,7 @@ void View::setVisible(bool is)
         if (m_visible) {
             // Mimic QWidgets: Set children visible, unless they were explicitly hidden
             for (auto child : qAsConst(m_childViews)) {
-                if (!child->isExpicitlyHidden()) {
+                if (!child->isExplicitlyHidden()) {
                     child->setVisible(true);
                 }
             }
@@ -99,7 +99,7 @@ void View::setVisible(bool is)
     }
 }
 
-bool View::isExpicitlyHidden() const
+bool View::isExplicitlyHidden() const
 {
     return m_visible.has_value() && !m_visible.value();
 }
@@ -241,7 +241,7 @@ void View::setParent(Core::View *parent)
         // Track it in C++
         m_parentView->m_childViews.append(this);
 
-        if (!m_parentView->isVisible() && isExpicitlyHidden()) {
+        if (!m_parentView->isVisible() && isExplicitlyHidden()) {
             // Mimic QtWidget. Parenting removes the explicit hidden attribute if the parent is not visible
             m_visible = std::nullopt;
         }

--- a/src/flutter/views/View.h
+++ b/src/flutter/views/View.h
@@ -48,7 +48,7 @@ public:
 
     bool isVisible() const override;
     void setVisible(bool visible) override;
-    bool isExpicitlyHidden() const override;
+    bool isExplicitlyHidden() const override;
 
     void move(int x, int y) override;
     void setSize(int w, int h) override;

--- a/src/flutter/views/ViewWrapper.cpp
+++ b/src/flutter/views/ViewWrapper.cpp
@@ -54,9 +54,9 @@ void ViewWrapper::setVisible(bool is)
     m_wrappedView->setVisible(is);
 }
 
-bool ViewWrapper::isExpicitlyHidden() const
+bool ViewWrapper::isExplicitlyHidden() const
 {
-    return m_wrappedView->isExpicitlyHidden();
+    return m_wrappedView->isExplicitlyHidden();
 }
 
 void ViewWrapper::setSize(int w, int h)

--- a/src/flutter/views/ViewWrapper.h
+++ b/src/flutter/views/ViewWrapper.h
@@ -47,7 +47,7 @@ public:
 
     bool isVisible() const override;
     void setVisible(bool visible) override;
-    bool isExpicitlyHidden() const override;
+    bool isExplicitlyHidden() const override;
 
     void move(int x, int y) override;
     void setSize(int w, int h) override;

--- a/src/qtquick/views/View.cpp
+++ b/src/qtquick/views/View.cpp
@@ -349,7 +349,7 @@ void View::setVisible(bool is)
     QQuickItem::setVisible(is);
 }
 
-bool View::isExpicitlyHidden() const
+bool View::isExplicitlyHidden() const
 {
     auto priv = QQuickItemPrivate::get(this);
     return !priv->explicitVisible;

--- a/src/qtquick/views/View.h
+++ b/src/qtquick/views/View.h
@@ -73,7 +73,7 @@ public:
     void setMaximumSize(QSize sz) override;
 
     bool isVisible() const override;
-    bool isExpicitlyHidden() const override;
+    bool isExplicitlyHidden() const override;
     void setVisible(bool is) override;
 
     void move(int x, int y) override;

--- a/src/qtquick/views/ViewWrapper.cpp
+++ b/src/qtquick/views/ViewWrapper.cpp
@@ -193,7 +193,7 @@ bool ViewWrapper::isVisible() const
     return m_item->isVisible();
 }
 
-bool ViewWrapper::isExpicitlyHidden() const
+bool ViewWrapper::isExplicitlyHidden() const
 {
     auto priv = QQuickItemPrivate::get(m_item);
     return !priv->explicitVisible;

--- a/src/qtquick/views/ViewWrapper.h
+++ b/src/qtquick/views/ViewWrapper.h
@@ -31,7 +31,7 @@ public:
     QPoint mapFromGlobal(QPoint) const override;
     bool isRootView() const override;
     bool isVisible() const override;
-    bool isExpicitlyHidden() const override;
+    bool isExplicitlyHidden() const override;
     void setVisible(bool) override;
     void activateWindow() override;
     bool isMaximized() const override;

--- a/src/qtwidgets/views/View.h
+++ b/src/qtwidgets/views/View.h
@@ -109,7 +109,7 @@ public:
         return Base::isVisible();
     }
 
-    bool isExpicitlyHidden() const override
+    bool isExplicitlyHidden() const override
     {
         return Base::isHidden();
     }

--- a/src/qtwidgets/views/ViewWrapper.cpp
+++ b/src/qtwidgets/views/ViewWrapper.cpp
@@ -182,7 +182,7 @@ bool ViewWrapper::isVisible() const
     return m_widget->isVisible();
 }
 
-bool ViewWrapper::isExpicitlyHidden() const
+bool ViewWrapper::isExplicitlyHidden() const
 {
     return m_widget->isHidden();
 }

--- a/src/qtwidgets/views/ViewWrapper.h
+++ b/src/qtwidgets/views/ViewWrapper.h
@@ -32,7 +32,7 @@ public:
     bool isRootView() const override;
     bool isVisible() const override;
     void setVisible(bool) override;
-    bool isExpicitlyHidden() const override;
+    bool isExplicitlyHidden() const override;
     void activateWindow() override;
     bool isMaximized() const override;
     bool isMinimized() const override;

--- a/tests/tst_docks_slow3.cpp
+++ b/tests/tst_docks_slow3.cpp
@@ -143,8 +143,8 @@ KDDW_QCORO_TASK tst_close()
     CHECK(fw);
     CHECK(fw->isVisible());
     CHECK(toggleAction->isChecked());
-    CHECK(!dock1->view()->isExpicitlyHidden());
-    CHECK(!dock1->view()->isExpicitlyHidden());
+    CHECK(!dock1->view()->isExplicitlyHidden());
+    CHECK(!dock1->view()->isExplicitlyHidden());
     CHECK(dock1->isVisible());
     CHECK(dock1->window()->equals(fw->view()));
     CHECK(toggleAction->isChecked());


### PR DESCRIPTION
Fix typo in various classes from `Expicilty` to `Explicitly`. 

Note: there are many references to this method in generated bindings, as I could not find how to generate them, this might need to be done before merge. 