### PR TITLE
src/CMakeLists.txt - no longer need to require nlohmann_json

### DIFF
--- a/python/examples/MyWidget.py
+++ b/python/examples/MyWidget.py
@@ -19,7 +19,7 @@ from PySide2 import QtWidgets, QtGui, QtCore
 class MyWidget(QtWidgets.QWidget):
     s_images = {}
 
-    def __init__(self, backgroundFile = "", logoFile = "", parent = None):
+    def __init__(self, backgroundFile="", logoFile="", parent=None):
         super().__init__(parent)
 
         self.background = self._lookupImage(backgroundFile)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -550,14 +550,6 @@ if(KDDockWidgets_XLib)
     target_link_libraries(kddockwidgets PRIVATE X11)
 endif()
 
-find_package(nlohmann_json QUIET)
-if(nlohmann_json_FOUND)
-    target_link_libraries(kddockwidgets PRIVATE nlohmann_json::nlohmann_json)
-else()
-    message("nlohmann_json not found in system. Using our own bundled one")
-    target_include_directories(kddockwidgets SYSTEM PRIVATE 3rdparty/nlohmann)
-endif()
-
 set_target_properties(kddockwidgets PROPERTIES SOVERSION ${KDDockWidgets_SOVERSION} VERSION ${KDDockWidgets_VERSION})
 
 # version libraries on Windows


### PR DESCRIPTION
Currently the code only uses the nlohmann_json/json.hpp and not the entire nlohmann_json project.