### PR TITLE
src/CMakeLists.txt - no longer need to require nlohmann_json

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -550,13 +550,7 @@ if(KDDockWidgets_XLib)
     target_link_libraries(kddockwidgets PRIVATE X11)
 endif()
 
-find_package(nlohmann_json QUIET)
-if(nlohmann_json_FOUND)
-    target_link_libraries(kddockwidgets PRIVATE nlohmann_json::nlohmann_json)
-else()
-    message("nlohmann_json not found in system. Using our own bundled one")
-    target_include_directories(kddockwidgets SYSTEM PRIVATE 3rdparty/nlohmann)
-endif()
+target_include_directories(kddockwidgets SYSTEM PRIVATE 3rdparty/nlohmann)
 
 set_target_properties(kddockwidgets PROPERTIES SOVERSION ${KDDockWidgets_SOVERSION} VERSION ${KDDockWidgets_VERSION})
 


### PR DESCRIPTION
The code only uses the nlohmann_json/json.hpp and not the entire nlohmann_json project.