### PR TITLE
Remove of one the last deprecated usages of DockWidget::show()

### DIFF
--- a/src/core/DockWidget.cpp
+++ b/src/core/DockWidget.cpp
@@ -717,7 +717,7 @@ void DockWidget::Private::toggle(bool enabled)
     } else {
         // The most common case. The dock widget is not in the sidebar. just close or open it.
         if (enabled) {
-            q->show();
+            q->open();
         } else {
             q->view()->close();
         }


### PR DESCRIPTION
Noticed this when pulling apart toggleAction, seems to be one of the last references to this function (inside of KDDW)