### PR TITLE
Expose DockWidget::open() in QtQuick

### DIFF
--- a/src/qtquick/views/DockWidget.h
+++ b/src/qtquick/views/DockWidget.h
@@ -108,6 +108,7 @@ public:
     Q_INVOKABLE void setAsCurrentTab();
     Q_INVOKABLE void forceClose();
     Q_INVOKABLE bool isOpen() const;
+    Q_INVOKABLE void open();
     Q_INVOKABLE void show();
     Q_INVOKABLE void raise();
     Q_INVOKABLE void moveToSideBar();


### PR DESCRIPTION
Since `DockWidget::show()` is on it's way out, we should be able to start using the non-deprecated replacement in QtQuick as well.