### PR TITLE
Return current tab index instead of -1, in QtQuick TabBar

### DIFF
--- a/src/qtquick/views/qml/TabBar.qml
+++ b/src/qtquick/views/qml/TabBar.qml
@@ -69,7 +69,7 @@ TabBarBase {
             }
         }
 
-        return -1;
+        return tabBar.currentIndex;
     }
 
     implicitHeight: tabBar.implicitHeight


### PR DESCRIPTION
Not all Qt Quick Controls 2 styles have full-width tabs in their TabBars, so it's very easy to set an invalid tab index on blank tab bar space. Setting -1 makes the dock widget blank, and might crash the application when it loads the layout next. Instead, return the current tab index which doesn't change the tab.

For example, Breeze has empty space in it's tab bar:

![image](https://github.com/KDAB/KDDockWidgets/assets/54911369/dc4af8b9-aa9a-43c6-8582-f0f7cd3489e0)
