### PR TITLE
Implement QtQuick View::render()

### DIFF
--- a/src/core/WindowBeingDragged.cpp
+++ b/src/core/WindowBeingDragged.cpp
@@ -262,6 +262,7 @@ Pixmap WindowBeingDraggedWayland::pixmap() const
 #ifdef QT_GUI_LIB
     QPixmap pixmap(size());
     QPainter p(&pixmap);
+    pixmap.fill(Qt::transparent);
     p.setOpacity(0.7);
 
     if (m_floatingWindow) {

--- a/src/qtquick/views/View.cpp
+++ b/src/qtquick/views/View.cpp
@@ -779,12 +779,12 @@ void View::setMinimumSize(QSize sz)
     }
 }
 
-void View::render(QPainter * painter)
+void View::render(QPainter *painter)
 {
     if (QQuickWindow *w = QQuickItem::window()) {
         const QImage image = w->grabWindow();
 
-        const QRect sourceRect {asGroupController()->dragRect().topLeft() * image.devicePixelRatio(), painter->window().size() * image.devicePixelRatio()};
+        const QRect sourceRect { asGroupController()->dragRect().topLeft() * image.devicePixelRatio(), painter->window().size() * image.devicePixelRatio() };
         painter->drawImage(painter->window(), image, sourceRect);
     }
 }

--- a/src/qtquick/views/View.cpp
+++ b/src/qtquick/views/View.cpp
@@ -17,6 +17,7 @@
 #include "core/ScopedValueRollback_p.h"
 #include "kddockwidgets/qtquick/Window.h"
 #include "qtquick/Platform.h"
+#include "core/Group.h"
 
 #include <QtQuick/private/qquickitem_p.h>
 #include <qpa/qplatformwindow.h>
@@ -778,9 +779,14 @@ void View::setMinimumSize(QSize sz)
     }
 }
 
-void View::render(QPainter *)
+void View::render(QPainter * painter)
 {
-    qWarning() << Q_FUNC_INFO << "Implement me";
+    if (QQuickWindow *w = QQuickItem::window()) {
+        const QImage image = w->grabWindow();
+
+        const QRect sourceRect {asGroupController()->dragRect().topLeft() * image.devicePixelRatio(), painter->window().size() * image.devicePixelRatio()};
+        painter->drawImage(painter->window(), image, sourceRect);
+    }
 }
 
 void View::setCursor(Qt::CursorShape shape)


### PR DESCRIPTION
Adds a proper preview of the draggable on QtQuick Wayland, using QQuickWindow::grabWindow() and cropping it.

![image](https://github.com/KDAB/KDDockWidgets/assets/54911369/cfaf40b7-5beb-4a05-8c05-903f8f1589ff)

It's not perfect yet, I'm not sure of the best way to get the correct position of the view inside of the window.