### PR TITLE
Implement QtQuick Wayland DropArea

### DIFF
--- a/src/qtquick/views/DropArea.cpp
+++ b/src/qtquick/views/DropArea.cpp
@@ -13,6 +13,7 @@
 #include "core/Utils_p.h"
 #include "core/View_p.h"
 #include "kddockwidgets/core/DropArea.h"
+#include "qtcommon/DragControllerWayland_p.h"
 
 using namespace KDDockWidgets;
 using namespace KDDockWidgets::QtQuick;
@@ -22,13 +23,36 @@ DropArea::DropArea(Core::DropArea *dropArea, Core::View *parent)
     , m_dropArea(dropArea)
 {
     Q_ASSERT(dropArea);
-    if (isWayland()) {
-        qWarning() << "Dropping not implement for QtQuick on Wayland yet!";
-    }
+
+    auto item = createQQuickItem(QStringLiteral(":/kddockwidgets/qtquick/views/qml/DropArea.qml"), this);
+    Q_ASSERT(item);
+
+    qvariant_cast<QObject*>(item->property("anchors"))->setProperty("fill", QVariant::fromValue(asQQuickItem(this)));
+    item->setProperty("dropAreaCpp", QVariant::fromValue(this));
 }
 
 DropArea::~DropArea()
 {
     if (!Core::View::d->freed())
         m_dropArea->viewAboutToBeDeleted();
+}
+
+void DropArea::beginDrag(QPoint point, QObject *source)
+{
+    if (auto stateWayland = qobject_cast<Core::StateDraggingWayland*>(source)) {
+        m_dropArea->hover(stateWayland->q->windowBeingDragged(), point);
+    }
+}
+
+void DropArea::drop(QPoint point, QObject *source)
+{
+    if (auto stateWayland = qobject_cast<Core::StateDraggingWayland*>(source)) {
+        m_dropArea->drop(stateWayland->q->windowBeingDragged(), point);
+        stop();
+    }
+}
+
+void DropArea::stop()
+{
+    m_dropArea->removeHover();
 }

--- a/src/qtquick/views/DropArea.cpp
+++ b/src/qtquick/views/DropArea.cpp
@@ -27,7 +27,7 @@ DropArea::DropArea(Core::DropArea *dropArea, Core::View *parent)
     auto item = createQQuickItem(QStringLiteral(":/kddockwidgets/qtquick/views/qml/DropArea.qml"), this);
     Q_ASSERT(item);
 
-    qvariant_cast<QObject*>(item->property("anchors"))->setProperty("fill", QVariant::fromValue(asQQuickItem(this)));
+    qvariant_cast<QObject *>(item->property("anchors"))->setProperty("fill", QVariant::fromValue(asQQuickItem(this)));
     item->setProperty("dropAreaCpp", QVariant::fromValue(this));
 }
 
@@ -39,14 +39,14 @@ DropArea::~DropArea()
 
 void DropArea::beginDrag(QPoint point, QObject *source)
 {
-    if (auto stateWayland = qobject_cast<Core::StateDraggingWayland*>(source)) {
+    if (auto stateWayland = qobject_cast<Core::StateDraggingWayland *>(source)) {
         m_dropArea->hover(stateWayland->q->windowBeingDragged(), point);
     }
 }
 
 void DropArea::drop(QPoint point, QObject *source)
 {
-    if (auto stateWayland = qobject_cast<Core::StateDraggingWayland*>(source)) {
+    if (auto stateWayland = qobject_cast<Core::StateDraggingWayland *>(source)) {
         m_dropArea->drop(stateWayland->q->windowBeingDragged(), point);
         stop();
     }

--- a/src/qtquick/views/DropArea.h
+++ b/src/qtquick/views/DropArea.h
@@ -28,6 +28,10 @@ public:
     explicit DropArea(Core::DropArea *, Core::View *parent);
     ~DropArea();
 
+    Q_INVOKABLE void beginDrag(QPoint point, QObject* source);
+    Q_INVOKABLE void drop(QPoint point, QObject* source);
+    Q_INVOKABLE void stop();
+
 private:
     Core::DropArea *const m_dropArea;
 };

--- a/src/qtquick/views/DropArea.h
+++ b/src/qtquick/views/DropArea.h
@@ -28,8 +28,8 @@ public:
     explicit DropArea(Core::DropArea *, Core::View *parent);
     ~DropArea();
 
-    Q_INVOKABLE void beginDrag(QPoint point, QObject* source);
-    Q_INVOKABLE void drop(QPoint point, QObject* source);
+    Q_INVOKABLE void beginDrag(QPoint point, QObject *source);
+    Q_INVOKABLE void drop(QPoint point, QObject *source);
     Q_INVOKABLE void stop();
 
 private:

--- a/src/qtquick/views/qml/DropArea.qml
+++ b/src/qtquick/views/qml/DropArea.qml
@@ -11,7 +11,18 @@
 
 import QtQuick 2.9
 
-Item {
+DropArea {
     id: root
+
     property QtObject dropAreaCpp: null
+
+    onPositionChanged: (drag) => {
+        dropAreaCpp.beginDrag(mapToGlobal(drag.x, drag.y), drag.source);
+    }
+    onExited: (drag) => {
+        dropAreaCpp.stop();
+    }
+    onDropped: (drag) => {
+        dropAreaCpp.drop(mapToGlobal(drag.x, drag.y), drag.source);
+    }
 }


### PR DESCRIPTION
Initializes the DropArea properly, and listen to DragEvents in QML.

Still WIP, it does not interact with the indicators properly (or really at all) and it ends up stealing the drag events.