### PR TITLE
Fix includes for add_subdirectory builds

### DIFF
--- a/src/3rdparty/kdbindings/signal.h
+++ b/src/3rdparty/kdbindings/signal.h
@@ -19,8 +19,8 @@
 #include <type_traits>
 #include <utility>
 
-#include <kdbindings/genindex_array.h>
-#include <kdbindings/utils.h>
+#include "genindex_array.h"
+#include "utils.h"
 
 /**
  * @brief The main namespace of the KDBindings library.

--- a/src/qtquick/views/Group.h
+++ b/src/qtquick/views/Group.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include "View.h"
-#include "core/views/GroupViewInterface.h"
+#include "kddockwidgets/core/views/GroupViewInterface.h"
 #include "TitleBar.h"
 
 QT_BEGIN_NAMESPACE

--- a/src/qtquick/views/TabBar.h
+++ b/src/qtquick/views/TabBar.h
@@ -22,13 +22,13 @@
 #pragma once
 
 #include "View.h"
-#include "core/views/TabBarViewInterface.h"
+#include <kddockwidgets/core/views/TabBarViewInterface.h>
 
 #include <QAbstractListModel>
 #include <QPointer>
 #include <QHash>
 
-#include "kdbindings/signal.h"
+#include "../../3rdparty/kdbindings/signal.h"
 
 namespace KDDockWidgets {
 

--- a/src/qtquick/views/TitleBar.h
+++ b/src/qtquick/views/TitleBar.h
@@ -14,7 +14,7 @@
 #pragma once
 
 #include "kddockwidgets/docks_export.h"
-#include "core/views/TitleBarViewInterface.h"
+#include "kddockwidgets/core/views/TitleBarViewInterface.h"
 #include "View.h"
 
 namespace KDDockWidgets {


### PR DESCRIPTION
This PR refactors and fixes some header includes to get KDDockWidgets with the QtQuick backend building with branch `2.0` when included via CMake's `add_subdirectory` function from another project.

I had opened a pr a while ago to fix some similar issues but it was closed as there was a lot of churn on `2.0` at the time. I recently updated to the latest version of `2.0` (a8e0b2d8e2f60421541f233ba4b7be09cfbf0042) and encountered some similar issues though far fewer this time. This pr fixes up the few remaining includes that cause issues.

_See original closed pr for more info: https://github.com/KDAB/KDDockWidgets/pull/355_

