### PR TITLE
Add Wayland testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ project(
     KDDockWidgets
     DESCRIPTION "An advanced docking system for Qt"
     HOMEPAGE_URL "https://github.com/KDAB/KDDockWidgets"
-    LANGUAGES CXX
+    LANGUAGES CXX C
 )
 
 set(KDDockWidgets_VERSION_MAJOR 2)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -116,4 +116,6 @@ if(NOT KDDW_FRONTEND_FLUTTER)
     add_kddw_test(tst_docks_slow8 tst_docks_slow8.cpp)
 endif()
 
+add_subdirectory(wayland)
+
 #-----------------------------------------------------------------------------

--- a/tests/wayland/CMakeLists.txt
+++ b/tests/wayland/CMakeLists.txt
@@ -8,14 +8,22 @@ find_package(PlasmaWaylandProtocols)
 find_package(QtWaylandScanner)
 find_package(Wayland REQUIRED Client)
 
-ecm_add_qtwayland_client_protocol(wayland_SRCS
-        PROTOCOL ${PLASMA_WAYLAND_PROTOCOLS_DIR}/fake-input.xml
-        BASENAME fake-input)
+ecm_add_qtwayland_client_protocol(
+    wayland_SRCS PROTOCOL ${PLASMA_WAYLAND_PROTOCOLS_DIR}/fake-input.xml BASENAME fake-input
+)
 
 # add wayland test
 function(add_wayland_test test srcs)
     add_executable(${test} ${srcs})
-    target_link_libraries(${test} kddockwidgets kdbindings Wayland::Client Qt::WaylandClient KF${Qt_VERSION_MAJOR}::WaylandClient Qt::Concurrent)
+    target_link_libraries(
+        ${test}
+        kddockwidgets
+        kdbindings
+        Wayland::Client
+        Qt::WaylandClient
+        KF${Qt_VERSION_MAJOR}::WaylandClient
+        Qt::Concurrent
+    )
     if(KDDockWidgets_HAS_SPDLOG)
         target_link_libraries(${test} spdlog::spdlog)
     endif()
@@ -24,7 +32,9 @@ function(add_wayland_test test srcs)
     set_compiler_flags(${test})
 
     # FIXME: Use find_program to check if kwin_wayland exists first
-    add_test(NAME ${test} COMMAND kwin_wayland --no-kactivities --no-global-shortcuts --no-lockscreen --virtual --exit-with-session $<TARGET_FILE:${test}>)
+    add_test(NAME ${test} COMMAND kwin_wayland --no-kactivities --no-global-shortcuts --no-lockscreen --virtual
+                                  --exit-with-session $<TARGET_FILE:${test}>
+    )
 endfunction()
 
 add_wayland_test(tst_wayland_qtwidgets tst_qtwidgets.cpp)

--- a/tests/wayland/CMakeLists.txt
+++ b/tests/wayland/CMakeLists.txt
@@ -1,0 +1,30 @@
+find_package(KF${Qt_VERSION_MAJOR}Wayland CONFIG)
+find_package(Qt${Qt_VERSION_MAJOR} COMPONENTS WaylandClient Concurrent)
+
+find_package(ECM ${KF5_MIN_VERSION} REQUIRED NO_MODULE)
+set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake)
+
+find_package(PlasmaWaylandProtocols)
+find_package(QtWaylandScanner)
+find_package(Wayland REQUIRED Client)
+
+ecm_add_qtwayland_client_protocol(wayland_SRCS
+        PROTOCOL ${PLASMA_WAYLAND_PROTOCOLS_DIR}/fake-input.xml
+        BASENAME fake-input)
+
+# add wayland test
+function(add_wayland_test test srcs)
+    add_executable(${test} ${srcs})
+    target_link_libraries(${test} kddockwidgets kdbindings Wayland::Client Qt::WaylandClient KF${Qt_VERSION_MAJOR}::WaylandClient Qt::Concurrent)
+    if(KDDockWidgets_HAS_SPDLOG)
+        target_link_libraries(${test} spdlog::spdlog)
+    endif()
+    target_sources(${test} PRIVATE ${wayland_SRCS})
+    kddw_add_nlohmann(${test})
+    set_compiler_flags(${test})
+
+    # FIXME: Use find_program to check if kwin_wayland exists first
+    add_test(NAME ${test} COMMAND kwin_wayland --no-kactivities --no-global-shortcuts --no-lockscreen --virtual --exit-with-session $<TARGET_FILE:${test}>)
+endfunction()
+
+add_wayland_test(tst_wayland_qtwidgets tst_qtwidgets.cpp)

--- a/tests/wayland/tst_qtwidgets.cpp
+++ b/tests/wayland/tst_qtwidgets.cpp
@@ -1,0 +1,237 @@
+#include <QApplication>
+#include <QLabel>
+#include <QScreen>
+#include <QSignalSpy>
+#include <QStyle>
+#include <QVBoxLayout>
+#include <QtConcurrent>
+#include <QGuiApplication>
+
+#include <KWayland/Client/connection_thread.h>
+#include <KWayland/Client/fakeinput.h>
+#include <KWayland/Client/registry.h>
+
+#include "kddockwidgets/DockWidget.h"
+#include "kddockwidgets/MainWindow.h"
+#include "kddockwidgets/core/Group.h"
+#include "kddockwidgets/core/Platform.h"
+#include "kddockwidgets/core/TabBar.h"
+#include "kddockwidgets/core/TitleBar.h"
+#include "kddockwidgets/core/FloatingWindow.h"
+#include "qtwidgets/views/FloatingWindow.h"
+#include "qtwidgets/views/TabBar.h"
+
+static KWayland::Client::FakeInput* input = nullptr;
+
+QPoint getWindowTopLeft()
+{
+    const int titlebarHeight = QApplication::style()->pixelMetric(QStyle::PM_TitleBarHeight);
+    return {0, titlebarHeight + 10};
+}
+
+QPoint getCenterOfTitlebar(const KDDockWidgets::QtWidgets::DockWidget &dockWidget)
+{
+    return dockWidget.actualTitleBar()->rect().center();
+}
+
+QPoint getCenterOfDockWidget(const KDDockWidgets::QtWidgets::DockWidget &dockWidget)
+{
+    return dockWidget.rect().center();
+}
+
+KDDockWidgets::QtWidgets::MainWindow *createMainWindow(const QString &name)
+{
+    auto mainWindow = new KDDockWidgets::QtWidgets::MainWindow(name);
+    mainWindow->showMaximized();
+
+    return mainWindow;
+}
+
+KDDockWidgets::QtWidgets::DockWidget *createDockWidget(const QString &name)
+{
+    auto dockWidget = new KDDockWidgets::QtWidgets::DockWidget(name);
+    dockWidget->setWidget(new QWidget());
+    return dockWidget;
+}
+
+// A QFuture for running the test, and the testing/cleanup function.
+using TestFunc = std::pair<QFuture<void>, std::function<void()>>;
+
+TestFunc tst_detachTitlebar()
+{
+    auto mainWindow = createMainWindow("detachtitle_window");
+
+    auto dockWidget = createDockWidget(QStringLiteral("detachtitle_dock"));
+    mainWindow->addDockWidget(dockWidget, KDDockWidgets::Location::Location_OnTop);
+
+    auto tabbedDockWidget = createDockWidget(QStringLiteral("detachtitle_dock2"));
+    mainWindow->addDockWidget(tabbedDockWidget, KDDockWidgets::Location::Location_OnRight);
+
+    return {QtConcurrent::run([=]() {
+                // wait to settle
+                QThread::msleep(1000);
+
+                input->requestPointerMoveAbsolute(getWindowTopLeft() + getCenterOfTitlebar(*dockWidget));
+                input->requestPointerButtonPress(Qt::MouseButton::LeftButton);
+                QThread::msleep(1000);
+                input->requestPointerMoveAbsolute(getWindowTopLeft() + getCenterOfDockWidget(*dockWidget));
+                QThread::msleep(4000);
+                input->requestPointerButtonRelease(Qt::MouseButton::LeftButton);
+                QThread::msleep(1000);
+            }), [=]() {
+                Q_ASSERT(dockWidget->isFloating());
+                mainWindow->close();
+                tabbedDockWidget->close();
+
+                mainWindow->deleteLater();
+                tabbedDockWidget->deleteLater();
+            }};
+}
+
+TestFunc tst_detachTab()
+{
+    auto mainWindow = createMainWindow("detachtab_window");
+
+    auto dockWidget = createDockWidget(QStringLiteral("detachtab_dock"));
+    mainWindow->addDockWidget(dockWidget, KDDockWidgets::Location::Location_OnTop);
+
+    auto tabbedDockWidget = createDockWidget(QStringLiteral("detachtab_dock2"));
+    dockWidget->addDockWidgetAsTab(tabbedDockWidget);
+
+    auto tabBar = dynamic_cast<KDDockWidgets::QtWidgets::TabBar*>(dockWidget->group()->tabBar()->view());
+
+    return {QtConcurrent::run([=]() {
+                // wait to settle
+                QThread::msleep(1000);
+
+                const QRect secondTabRect = tabBar->rectForTab(1);
+
+                input->requestPointerMoveAbsolute(getWindowTopLeft() + tabBar->mapToGlobal(secondTabRect.center()));
+                input->requestPointerButtonClick(Qt::MouseButton::LeftButton);
+                QThread::msleep(10);
+                input->requestPointerButtonClick(Qt::MouseButton::LeftButton);
+                QThread::msleep(1000);
+            }), [=]() {
+                Q_ASSERT(tabbedDockWidget->isFloating());
+                mainWindow->close();
+                tabbedDockWidget->close();
+
+                mainWindow->deleteLater();
+                tabbedDockWidget->deleteLater();
+            }};
+}
+
+TestFunc tst_dragAndDrop()
+{
+    auto mainWindow = createMainWindow("draganddrop_window");
+
+    auto dummyWidget = new QWidget();
+    auto layout = new QVBoxLayout();
+    dummyWidget->setLayout(layout);
+
+    auto timeLabel = new QLabel("time:");
+    layout->addWidget(timeLabel);
+
+    // FIXME: This timer seems to be required for the tests to work? QEventLoop weirdness I bet...
+    auto timer = new QTimer();
+    timer->setInterval(1000);
+    timer->setSingleShot(false);
+    QObject::connect(timer, &QTimer::timeout, timer, [timeLabel] {
+        static int time = 0;
+        timeLabel->setText(QString("time: %1").arg(time++));
+    });
+    timer->start();
+
+    auto dockWidget = createDockWidget(QStringLiteral("draganddrop_dock"));
+    dockWidget->setWidget(dummyWidget);
+
+    mainWindow->addDockWidget(dockWidget, KDDockWidgets::Location::Location_OnTop);
+
+    auto tabbedDockWidget = createDockWidget(QStringLiteral("draganddrop_dock2"));
+    tabbedDockWidget->open();
+
+    auto window = dynamic_cast<KDDockWidgets::QtWidgets::FloatingWindow*>(tabbedDockWidget->group()->floatingWindow()->view());
+    window->showMaximized();
+
+    return {QtConcurrent::run([=]() {
+                // wait to settle
+                QThread::msleep(5000);
+
+                input->requestPointerMoveAbsolute(getWindowTopLeft() + getCenterOfTitlebar(*tabbedDockWidget));
+                QThread::msleep(1000);
+                input->requestPointerButtonPress(Qt::MouseButton::LeftButton);
+                QThread::msleep(1000);
+
+                input->requestPointerMove({100, 100});
+                QThread::msleep(1000);
+
+                window->hide();
+
+                input->requestPointerMoveAbsolute(getWindowTopLeft() + getCenterOfDockWidget(*dockWidget));
+                QThread::msleep(1000);
+                input->requestPointerButtonRelease(Qt::MouseButton::LeftButton);
+                QThread::msleep(1000);
+            }), [=]() {
+                Q_ASSERT(!tabbedDockWidget->isFloating());
+
+                mainWindow->close();
+                tabbedDockWidget->close();
+
+                mainWindow->deleteLater();
+                tabbedDockWidget->deleteLater();
+            }};
+}
+
+const std::vector tests = {
+    tst_dragAndDrop,
+    tst_detachTab,
+    tst_detachTitlebar,
+};
+
+static QFutureWatcher<void> watcher;
+static std::function<void()> currentCleanupFunction;
+
+void nextTest()
+{
+    static int currentTest = 0;
+
+    if (currentTest >= static_cast<int>(tests.size())) {
+        QApplication::quit();
+        return;
+    }
+
+    const auto [future, cleanupFunction] = tests[currentTest++]();
+    currentCleanupFunction = cleanupFunction;
+
+    watcher.setFuture(future);
+}
+
+int main(int argc, char **argv)
+{
+    QApplication app(argc, argv);
+
+    KWayland::Client::ConnectionThread *connection = KWayland::Client::ConnectionThread::fromApplication(qGuiApp);
+
+    QObject::connect(&watcher, &QFutureWatcher<void>::finished, [] {
+        currentCleanupFunction();
+        nextTest();
+    });
+
+    KWayland::Client::Registry registry;
+    registry.create(connection);
+    registry.setup();
+
+    QSignalSpy fakeInputSpy(&registry, &KWayland::Client::Registry::fakeInputAnnounced);
+    fakeInputSpy.wait();
+
+    const QList<QVariant> arguments = fakeInputSpy.takeFirst();
+
+    input = registry.createFakeInput(arguments[0].toInt(), arguments[1].toInt(), connection);
+    input->authenticate(QStringLiteral("KDDockWidgets Wayland Test"), QStringLiteral("For testing"));
+
+    KDDockWidgets::initFrontend(KDDockWidgets::FrontendType::QtWidgets);
+
+    nextTest();
+
+    return QApplication::exec();
+}

--- a/tests/wayland/tst_qtwidgets.cpp
+++ b/tests/wayland/tst_qtwidgets.cpp
@@ -21,12 +21,12 @@
 #include "qtwidgets/views/FloatingWindow.h"
 #include "qtwidgets/views/TabBar.h"
 
-static KWayland::Client::FakeInput* input = nullptr;
+static KWayland::Client::FakeInput *input = nullptr;
 
 QPoint getWindowTopLeft()
 {
     const int titlebarHeight = QApplication::style()->pixelMetric(QStyle::PM_TitleBarHeight);
-    return {0, titlebarHeight + 10};
+    return { 0, titlebarHeight + 10 };
 }
 
 QPoint getCenterOfTitlebar(const KDDockWidgets::QtWidgets::DockWidget &dockWidget)
@@ -67,25 +67,26 @@ TestFunc tst_detachTitlebar()
     auto tabbedDockWidget = createDockWidget(QStringLiteral("detachtitle_dock2"));
     mainWindow->addDockWidget(tabbedDockWidget, KDDockWidgets::Location::Location_OnRight);
 
-    return {QtConcurrent::run([=]() {
-                // wait to settle
-                QThread::msleep(1000);
+    return { QtConcurrent::run([=]() {
+                 // wait to settle
+                 QThread::msleep(1000);
 
-                input->requestPointerMoveAbsolute(getWindowTopLeft() + getCenterOfTitlebar(*dockWidget));
-                input->requestPointerButtonPress(Qt::MouseButton::LeftButton);
-                QThread::msleep(1000);
-                input->requestPointerMoveAbsolute(getWindowTopLeft() + getCenterOfDockWidget(*dockWidget));
-                QThread::msleep(4000);
-                input->requestPointerButtonRelease(Qt::MouseButton::LeftButton);
-                QThread::msleep(1000);
-            }), [=]() {
-                Q_ASSERT(dockWidget->isFloating());
-                mainWindow->close();
-                tabbedDockWidget->close();
+                 input->requestPointerMoveAbsolute(getWindowTopLeft() + getCenterOfTitlebar(*dockWidget));
+                 input->requestPointerButtonPress(Qt::MouseButton::LeftButton);
+                 QThread::msleep(1000);
+                 input->requestPointerMoveAbsolute(getWindowTopLeft() + getCenterOfDockWidget(*dockWidget));
+                 QThread::msleep(4000);
+                 input->requestPointerButtonRelease(Qt::MouseButton::LeftButton);
+                 QThread::msleep(1000);
+             }),
+             [=]() {
+                 Q_ASSERT(dockWidget->isFloating());
+                 mainWindow->close();
+                 tabbedDockWidget->close();
 
-                mainWindow->deleteLater();
-                tabbedDockWidget->deleteLater();
-            }};
+                 mainWindow->deleteLater();
+                 tabbedDockWidget->deleteLater();
+             } };
 }
 
 TestFunc tst_detachTab()
@@ -98,27 +99,28 @@ TestFunc tst_detachTab()
     auto tabbedDockWidget = createDockWidget(QStringLiteral("detachtab_dock2"));
     dockWidget->addDockWidgetAsTab(tabbedDockWidget);
 
-    auto tabBar = dynamic_cast<KDDockWidgets::QtWidgets::TabBar*>(dockWidget->group()->tabBar()->view());
+    auto tabBar = dynamic_cast<KDDockWidgets::QtWidgets::TabBar *>(dockWidget->group()->tabBar()->view());
 
-    return {QtConcurrent::run([=]() {
-                // wait to settle
-                QThread::msleep(1000);
+    return { QtConcurrent::run([=]() {
+                 // wait to settle
+                 QThread::msleep(1000);
 
-                const QRect secondTabRect = tabBar->rectForTab(1);
+                 const QRect secondTabRect = tabBar->rectForTab(1);
 
-                input->requestPointerMoveAbsolute(getWindowTopLeft() + tabBar->mapToGlobal(secondTabRect.center()));
-                input->requestPointerButtonClick(Qt::MouseButton::LeftButton);
-                QThread::msleep(10);
-                input->requestPointerButtonClick(Qt::MouseButton::LeftButton);
-                QThread::msleep(1000);
-            }), [=]() {
-                Q_ASSERT(tabbedDockWidget->isFloating());
-                mainWindow->close();
-                tabbedDockWidget->close();
+                 input->requestPointerMoveAbsolute(getWindowTopLeft() + tabBar->mapToGlobal(secondTabRect.center()));
+                 input->requestPointerButtonClick(Qt::MouseButton::LeftButton);
+                 QThread::msleep(10);
+                 input->requestPointerButtonClick(Qt::MouseButton::LeftButton);
+                 QThread::msleep(1000);
+             }),
+             [=]() {
+                 Q_ASSERT(tabbedDockWidget->isFloating());
+                 mainWindow->close();
+                 tabbedDockWidget->close();
 
-                mainWindow->deleteLater();
-                tabbedDockWidget->deleteLater();
-            }};
+                 mainWindow->deleteLater();
+                 tabbedDockWidget->deleteLater();
+             } };
 }
 
 TestFunc tst_dragAndDrop()
@@ -150,36 +152,37 @@ TestFunc tst_dragAndDrop()
     auto tabbedDockWidget = createDockWidget(QStringLiteral("draganddrop_dock2"));
     tabbedDockWidget->open();
 
-    auto window = dynamic_cast<KDDockWidgets::QtWidgets::FloatingWindow*>(tabbedDockWidget->group()->floatingWindow()->view());
+    auto window = dynamic_cast<KDDockWidgets::QtWidgets::FloatingWindow *>(tabbedDockWidget->group()->floatingWindow()->view());
     window->showMaximized();
 
-    return {QtConcurrent::run([=]() {
-                // wait to settle
-                QThread::msleep(5000);
+    return { QtConcurrent::run([=]() {
+                 // wait to settle
+                 QThread::msleep(5000);
 
-                input->requestPointerMoveAbsolute(getWindowTopLeft() + getCenterOfTitlebar(*tabbedDockWidget));
-                QThread::msleep(1000);
-                input->requestPointerButtonPress(Qt::MouseButton::LeftButton);
-                QThread::msleep(1000);
+                 input->requestPointerMoveAbsolute(getWindowTopLeft() + getCenterOfTitlebar(*tabbedDockWidget));
+                 QThread::msleep(1000);
+                 input->requestPointerButtonPress(Qt::MouseButton::LeftButton);
+                 QThread::msleep(1000);
 
-                input->requestPointerMove({100, 100});
-                QThread::msleep(1000);
+                 input->requestPointerMove({ 100, 100 });
+                 QThread::msleep(1000);
 
-                window->hide();
+                 window->hide();
 
-                input->requestPointerMoveAbsolute(getWindowTopLeft() + getCenterOfDockWidget(*dockWidget));
-                QThread::msleep(1000);
-                input->requestPointerButtonRelease(Qt::MouseButton::LeftButton);
-                QThread::msleep(1000);
-            }), [=]() {
-                Q_ASSERT(!tabbedDockWidget->isFloating());
+                 input->requestPointerMoveAbsolute(getWindowTopLeft() + getCenterOfDockWidget(*dockWidget));
+                 QThread::msleep(1000);
+                 input->requestPointerButtonRelease(Qt::MouseButton::LeftButton);
+                 QThread::msleep(1000);
+             }),
+             [=]() {
+                 Q_ASSERT(!tabbedDockWidget->isFloating());
 
-                mainWindow->close();
-                tabbedDockWidget->close();
+                 mainWindow->close();
+                 tabbedDockWidget->close();
 
-                mainWindow->deleteLater();
-                tabbedDockWidget->deleteLater();
-            }};
+                 mainWindow->deleteLater();
+                 tabbedDockWidget->deleteLater();
+             } };
 }
 
 const std::vector tests = {


### PR DESCRIPTION
This is an automatic, headless test for some common windowing operations on Wayland. Right now it tests for:
* Detaching windows via titlebar.
* Detaching windows via tabs.
* Dragging and dropping floating windows into the main window.

Sorry it took a while to finally get this into a semi-reviewable state. (Of course, Akademy got in the way too :smile:) Never done anything like this before, but it was really fun to figure this out.

This runs `kwin_wayland` in the virtual framebuffer mode so it doesn't require a graphical environment, suitable for CI. KDE also uses this for testing KWin on their CI. The tests use the fake input protocol to send events as if you were using a mouse (it will be totally transparent to us through Qt :-)

While it does work, I'm not completely satisfied with how it works right now:

- [ ] The event loop is wonky here, I used a QTimer (started in `tst_dragAndDrop`) to see if I accidentally blocked the Qt event loop but it seems to be required for the tests to even run. I'll pull this out eventually, but when I remove it the fake input seems to stop processing - blocking somewhere maybe?
- [ ] Timing is guesstimates still, it could probably be halved for all tests.
- [ ] For the fake input protocol to even be exposed, [you need a .desktop file installed onto the system](https://gist.github.com/redstrate/c9a0b68f3c76a7308c4fd6adfd66f4fe) - it doesn't need to be `/usr` but could even be in `$HOME`. Should probably do this in CMake?
- [ ] Need to check if `kwin_wayland` even exists before trying to add the test.
- [ ] How would this even be run on the CI? We'll probably need to grab `kwin_wayland` from somewhere right, or...?