### PR TITLE
Add a flag supporting hiding/showing tabbed dock widgets as group

### DIFF
--- a/src/Config.h
+++ b/src/Config.h
@@ -106,6 +106,7 @@ public:
         Flag_CloseOnlyCurrentTab = 0x20000, ///< The TitleBar's close button will only close the current tab, instead of all of them
         Flag_ShowButtonsOnTabBarIfTitleBarHidden = 0x40000, ///< When using Flag_HideTitleBarWhenTabsVisible the close/float buttons disappear with the title bar. With Flag_ShowButtonsOnTabBarIfHidden they'll be shown in the tab bar.
         Flag_AllowSwitchingTabsViaMenu = 0x80000, ///< Allow switching tabs via a context menu when right clicking on the tab area
+        Flag_AutoHideAsTabGroups = 0x100000, ///< If tabbed dockwidgets are hidden, they're hidden and restored together
         Flag_Default = Flag_AeroSnapWithClientDecos ///< The defaults
     };
     Q_DECLARE_FLAGS(Flags, Flag)

--- a/src/DockWidgetBase.h
+++ b/src/DockWidgetBase.h
@@ -573,5 +573,6 @@ private:
 
 }
 Q_DECLARE_METATYPE(KDDockWidgets::Location)
+Q_DECLARE_METATYPE(KDDockWidgets::DockWidgetBase::List)
 
 #endif


### PR DESCRIPTION
If dock widgets which are tabbed are hidden with the unpin button they all get hidden. However, when re-pinning them again only the clicked one is being restored. This supports re-pinning all of those which were in the same flag.