### PR TITLE
Keep track of override cursor in WidgetResizeHandler

### DIFF
--- a/src/private/WidgetResizeHandler.cpp
+++ b/src/private/WidgetResizeHandler.cpp
@@ -506,18 +506,28 @@ void WidgetResizeHandler::updateCursor(CursorPosition m)
 
 void WidgetResizeHandler::setMouseCursor(Qt::CursorShape cursor)
 {
-    if (m_usesGlobalEventFilter)
-        qApp->setOverrideCursor(cursor);
-    else
+    if (m_usesGlobalEventFilter) {
+        if (m_overrideCursorSet) {
+            qApp->changeOverrideCursor(cursor);
+        } else {
+            qApp->setOverrideCursor(cursor);
+            m_overrideCursorSet = true;
+        }
+    } else {
         mTarget->setCursor(cursor);
+    }
 }
 
 void WidgetResizeHandler::restoreMouseCursor()
 {
-    if (m_usesGlobalEventFilter)
-        qApp->restoreOverrideCursor();
-    else
+    if (m_usesGlobalEventFilter) {
+        if (m_overrideCursorSet) {
+            qApp->restoreOverrideCursor();
+            m_overrideCursorSet = false;
+        }
+    } else {
         mTarget->setCursor(Qt::ArrowCursor);
+    }
 }
 
 CursorPosition WidgetResizeHandler::cursorPosition(QPoint globalPos) const

--- a/src/private/WidgetResizeHandler_p.h
+++ b/src/private/WidgetResizeHandler_p.h
@@ -167,6 +167,7 @@ private:
     const bool m_isTopLevelWindowResizer;
     int m_resizeGap = 10;
     CursorPositions mAllowedResizeSides = CursorPosition_All;
+    bool m_overrideCursorSet = false;
 };
 
 #if defined(Q_OS_WIN) && defined(KDDOCKWIDGETS_QTWIDGETS)


### PR DESCRIPTION
QGuiApplication keeps a stack of override cursor and the number of setOverrideCursor calls must match the number of restoreOverrideCursor calls. Keep track of whether we've already set the override cursor in WidgetResizeHandler so we don't end up with the wrong cursor when restoring.