### PR TITLE
various - include guards. use 'pragma once'

### DIFF
--- a/src/core/indicators/ClassicDropIndicatorOverlay.h
+++ b/src/core/indicators/ClassicDropIndicatorOverlay.h
@@ -9,8 +9,7 @@
   Contact KDAB at <info@kdab.com> for commercial licensing options.
 */
 
-#ifndef KD_INDICATORS_CLASSICINDICATORS_P_H
-#define KD_INDICATORS_CLASSICINDICATORS_P_H
+#pragma once
 
 #include "core/DropIndicatorOverlay.h"
 
@@ -52,5 +51,3 @@ private:
 }
 
 }
-
-#endif

--- a/src/core/indicators/NullDropIndicatorOverlay.h
+++ b/src/core/indicators/NullDropIndicatorOverlay.h
@@ -9,8 +9,7 @@
   Contact KDAB at <info@kdab.com> for commercial licensing options.
 */
 
-#ifndef KD_NULL_INDICATORS_P_H
-#define KD_NULL_INDICATORS_P_H
+#pragma once
 
 #include "core/DropIndicatorOverlay.h"
 
@@ -49,5 +48,3 @@ protected:
 }
 
 }
-
-#endif

--- a/src/core/indicators/SegmentedDropIndicatorOverlay.h
+++ b/src/core/indicators/SegmentedDropIndicatorOverlay.h
@@ -9,8 +9,7 @@
   Contact KDAB at <info@kdab.com> for commercial licensing options.
 */
 
-#ifndef KD_SEGMENTED_INDICATORS_P_H
-#define KD_SEGMENTED_INDICATORS_P_H
+#pragma once
 
 #include <kddockwidgets/QtCompat_p.h>
 #include <kddockwidgets/core/DropIndicatorOverlay.h>
@@ -52,5 +51,3 @@ private:
 }
 
 }
-
-#endif

--- a/src/core/nlohmann_helpers_p.h
+++ b/src/core/nlohmann_helpers_p.h
@@ -8,8 +8,8 @@
 
   Contact KDAB at <info@kdab.com> for commercial licensing options.
 */
-#ifndef KDAB_NLOHMANN_JSON_QT_HELPERS_H
-#define KDAB_NLOHMANN_JSON_QT_HELPERS_H
+
+#pragma once
 
 #include "Logging_p.h"
 #include "QtCompat_p.h"
@@ -106,5 +106,3 @@ inline void from_json(const nlohmann::json &j, QRect &rect)
 #endif
 
 QT_END_NAMESPACE
-
-#endif

--- a/src/flutter/bindings_global.h
+++ b/src/flutter/bindings_global.h
@@ -9,6 +9,7 @@
   Contact KDAB at <info@kdab.com> for commercial licensing options.
 */
 
+#pragma once
 
 // TODOm4: Remove ?
 #ifndef DOCKS_DEVELOPER_MODE

--- a/src/flutter/views/DockWidget.h
+++ b/src/flutter/views/DockWidget.h
@@ -9,6 +9,8 @@
   Contact KDAB at <info@kdab.com> for commercial licensing options.
 */
 
+#pragma once
+
 /**
  * @file
  * @brief Represents a dock widget.

--- a/src/qtquick/views/MDILayout.h
+++ b/src/qtquick/views/MDILayout.h
@@ -9,6 +9,8 @@
   Contact KDAB at <info@kdab.com> for commercial licensing options.
 */
 
+#pragma once
+
 #include "kddockwidgets/docks_export.h"
 #include "kddockwidgets/KDDockWidgets.h"
 

--- a/src/qtwidgets/views/MDILayout.h
+++ b/src/qtwidgets/views/MDILayout.h
@@ -9,6 +9,8 @@
   Contact KDAB at <info@kdab.com> for commercial licensing options.
 */
 
+#pragma once
+
 #include "kddockwidgets/docks_export.h"
 #include "kddockwidgets/KDDockWidgets.h"
 #include "kddockwidgets/qtwidgets/views/View.h"

--- a/src/qtwidgets/views/RubberBand.h
+++ b/src/qtwidgets/views/RubberBand.h
@@ -9,6 +9,8 @@
   Contact KDAB at <info@kdab.com> for commercial licensing options.
 */
 
+#pragma once
+
 #include "View.h"
 
 #include <QRubberBand>


### PR DESCRIPTION
in some files there was no include guard at all.
in some files the macro name didn't properly match the filename.