### PR TITLE
Revert "cmake: Remove --warnings-as-errors=* from the clang-tidy preset"

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -384,7 +384,7 @@
                 "release"
             ],
             "cacheVariables": {
-                "CMAKE_CXX_CLANG_TIDY": "clang-tidy",
+                "CMAKE_CXX_CLANG_TIDY": "clang-tidy;--warnings-as-errors=*",
                 "KDDockWidgets_EXAMPLES": "OFF"
             }
         },


### PR DESCRIPTION
This reverts commit 97f2743a71a0069bd0eaf698c9c755fed89e9f0d.

All clang-tidy warnings have been fixed