### PR TITLE
cmake: Added KDDockWidgets_SEPARATE_LAYOUTING_LIBRARY

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,11 @@ option(KDDockWidgets_NO_SPDLOG "Don't use spdlog, even if it is found." OFF)
 option(KDDockWidgets_USE_LLD "Use lld for linking" OFF)
 option(KDDockWidgets_USE_VALGRIND "Runs the tests under valgrind" OFF)
 
+# Layouting engine library can be reused by non-KDDW projects
+option(KDDockWidgets_SEPARATE_LAYOUTING_LIBRARY
+       "Additionally builds the layouting engine as a standalone library. (Experimental)" OFF
+)
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/ECM/modules")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/KDAB/modules")
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -196,6 +196,20 @@
             ]
         },
         {
+            "name": "dev-layouting",
+            "description": "Builds the layouting engine library, for non-KDDW projects",
+            "binaryDir": "${sourceDir}/build-dev-layouting",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "KDDockWidgets_SEPARATE_LAYOUTING_LIBRARY": "ON",
+                "KDDockWidgets_FRONTENDS": "none",
+                "KDDockWidgets_NO_SPDLOG": "ON"
+            },
+            "inherits": [
+                "base"
+            ]
+        },
+        {
             "name": "clazy",
             "displayName": "clazy",
             "generator": "Ninja",

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -555,18 +555,7 @@ if(KDDockWidgets_XLib)
     target_link_libraries(kddockwidgets PRIVATE X11)
 endif()
 
-find_package(nlohmann_json QUIET)
-
-# Function to link to nlohmann
-function(link_to_nlohman target)
-    if(nlohmann_json_FOUND)
-        target_link_libraries(${target} PRIVATE nlohmann_json::nlohmann_json)
-    else()
-        message("nlohmann_json not found in system. Using our own bundled one")
-        target_include_directories(${target} SYSTEM PRIVATE ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/3rdparty/nlohmann)
-    endif()
-endfunction()
-
+include(nlohmann.cmake)
 link_to_nlohman(kddockwidgets)
 
 set_target_properties(kddockwidgets PROPERTIES SOVERSION ${KDDockWidgets_SOVERSION} VERSION ${KDDockWidgets_VERSION})
@@ -748,4 +737,8 @@ if(KDDockWidgets_DEVELOPER_MODE AND KDDW_FRONTEND_QTWIDGETS)
         target_link_libraries(kddockwidgets_linter PRIVATE kddockwidgets)
         link_to_nlohman(kddockwidgets_linter)
     endif()
+endif()
+
+if(KDDockWidgets_SEPARATE_LAYOUTING_LIBRARY)
+    add_subdirectory(core/layouting)
 endif()

--- a/src/core/layouting/CMakeLists.txt
+++ b/src/core/layouting/CMakeLists.txt
@@ -1,0 +1,41 @@
+#
+# This file is part of KDDockWidgets.
+#
+# SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# Author: Sergio Martins <sergio.martins@kdab.com>
+#
+# SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+#
+# Contact KDAB at <info@kdab.com> for commercial licensing options.
+
+# This is the CMakeLists.txt used by passing -DKDDockWidgets_SEPARATE_LAYOUTING_LIBRARY=ON
+
+cmake_minimum_required(VERSION 3.21)
+
+project(
+    KDDockWidgets
+    DESCRIPTION "KDDockWidgets standalone layouting library"
+    HOMEPAGE_URL "https://github.com/KDAB/KDDockWidgets"
+    LANGUAGES CXX C
+)
+
+set(KDDW_LAYOUTING_SRCS Item.cpp ItemFreeContainer.cpp ../../qtcompat/Object.cpp)
+
+add_library(kddockwidgetslayouting SHARED ${KDDW_LAYOUTING_SRCS})
+
+target_include_directories(
+    kddockwidgetslayouting
+    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../fwd_headers>
+           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../core>
+           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..> $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
+)
+
+target_link_libraries(kddockwidgetslayouting PRIVATE kdbindings)
+
+include(../../nlohmann.cmake)
+link_to_nlohman(kddockwidgetslayouting)
+
+include(GenerateExportHeader)
+generate_export_header(
+    kddockwidgetslayouting EXPORT_FILE_NAME "${CMAKE_BINARY_DIR}/kddockwidgets_export.h" EXPORT_MACRO_NAME DOCKS_EXPORT
+)

--- a/src/nlohmann.cmake
+++ b/src/nlohmann.cmake
@@ -1,0 +1,21 @@
+#
+# This file is part of KDDockWidgets.
+#
+# SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# Author: Sergio Martins <sergio.martins@kdab.com>
+#
+# SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+#
+# Contact KDAB at <info@kdab.com> for commercial licensing options.
+
+find_package(nlohmann_json QUIET)
+
+# Function to link to nlohmann
+function(link_to_nlohman target)
+    if(nlohmann_json_FOUND)
+        target_link_libraries(${target} PRIVATE nlohmann_json::nlohmann_json)
+    else()
+        message("nlohmann_json not found in system. Using our own bundled one")
+        target_include_directories(${target} SYSTEM PRIVATE ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/3rdparty/nlohmann)
+    endif()
+endfunction()


### PR DESCRIPTION
This generates a libkddockwidgetslayouting.so with Item.cpp. So non-KDDW projects can use the layouting.