### PR TITLE
examples: Create the executables inside bin/

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -505,20 +505,6 @@ if(KDDockWidgets_EXAMPLES)
 
         # Standalone layouting example
         add_subdirectory(src/core/layouting/examples/qtwidgets/)
-
-        set_target_properties(
-            qtwidgets_dockwidgets PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/examples/"
-        )
-        set_target_properties(
-            qtwidgets_mdi_with_docking PROPERTIES RUNTIME_OUTPUT_DIRECTORY
-                                                  "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/examples/"
-        )
-        set_target_properties(
-            qtwidgets_mdi PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/examples/"
-        )
-        set_target_properties(
-            qtwidgets_minimal PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/examples/"
-        )
     endif()
 
     if(KDDW_FRONTEND_FLUTTER AND NOT KDDockWidgets_FLUTTER_NO_BINDINGS)

--- a/docs/book/src/examples_qtquick_full.md
+++ b/docs/book/src/examples_qtquick_full.md
@@ -8,7 +8,7 @@ that are supported by our QtQuick implementation but just not showed in the exam
 
 View the source at [GitHub](https://github.com/KDAB/KDDockWidgets/blob/2.0/examples/qtquick/dockwidgets/).
 
-Run `./bin/examples/qtquick_dockwidgets --help` to see the available options:
+Run `./bin/qtquick_dockwidgets --help` to see the available options:
 
 ```bash
 KDDockWidgets example application

--- a/docs/book/src/examples_qtwidgets_full.md
+++ b/docs/book/src/examples_qtwidgets_full.md
@@ -7,10 +7,10 @@ View the source in [GitHub](https://github.com/KDAB/KDDockWidgets/blob/2.0/examp
 
 If you just want to get started quickly, see the [minimal](examples_qtwidgets_minimal.md) instead.
 
-Run `./bin/examples/qtwidgets_dockwidgets --help` to see the available options:
+Run `./bin/qtwidgets_dockwidgets --help` to see the available options:
 
 ```bash
-Usage: ./bin/examples/qtwidgets_dockwidgets [options] savedlayout
+Usage: ./bin/qtwidgets_dockwidgets [options] savedlayout
 KDDockWidgets example application
 
 Options:

--- a/docs/book/src/installation_and_usage.md
+++ b/docs/book/src/installation_and_usage.md
@@ -47,7 +47,7 @@ Let's start by building an example:
 cd path/to/kddockwidgets/examples/dockwidgets/
 cmake -G Ninja -DCMAKE_PREFIX_PATH=/path/where/to/install
 cmake --build .
-./bin/examples/qtwidgets_dockwidgets
+./bin/qtwidgets_dockwidgets
 ```
 
 ## Linking your own app to KDDockWidgets

--- a/examples/dockwidgets/MyTitleBar_CSS.h
+++ b/examples/dockwidgets/MyTitleBar_CSS.h
@@ -23,7 +23,7 @@
  * Derive from KDDockWidgets::QtWidgets::ViewFactory and override the createTitleBar() method.
  *
  * To try it out, modify examples/dockwidgets/MyViewFactory.cpp to return a MyTitleBar_CSS instance.
- * Run the example with: ./bin/examples/qtwidgets_dockwidgets -p
+ * Run the example with: ./bin/qtwidgets_dockwidgets -p
  *
  * WARNINGS:
  *   - Qt StyleSheets are not recommended for new applications. Often you are able to style 90% of

--- a/examples/qtquick/CMakeLists.txt
+++ b/examples/qtquick/CMakeLists.txt
@@ -9,16 +9,8 @@
 # Contact KDAB at <info@kdab.com> for commercial licensing options.
 #
 
-# Adds a qtquick example target
-function(kddw_add_qtquick_example name)
-    add_subdirectory(${name})
-    set_target_properties(
-        qtquick_${name} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/examples/"
-    )
-endfunction()
-
-kddw_add_qtquick_example(dockwidgets)
-kddw_add_qtquick_example(mdi)
-kddw_add_qtquick_example(customtitlebar)
-kddw_add_qtquick_example(customtabbar)
-kddw_add_qtquick_example(customseparator)
+add_subdirectory(dockwidgets)
+add_subdirectory(mdi)
+add_subdirectory(customtitlebar)
+add_subdirectory(customtabbar)
+add_subdirectory(customseparator)


### PR DESCRIPTION
Instead of bin/examples/

This way they are next to the kddockwidgets.dll in Windows, which does not support rpath.

Also nicer for WASM, which needs the .js files next to the html