### PR TITLE
Fix window frames when using showMinimized() on Windows

### DIFF
--- a/src/core/FloatingWindow.cpp
+++ b/src/core/FloatingWindow.cpp
@@ -580,6 +580,10 @@ bool FloatingWindow::deserialize(const LayoutSaver::FloatingWindow &fw)
         if (int(fw.windowState) & int(WindowState::Maximized)) {
             view()->showMaximized();
         } else if (int(fw.windowState) & int(WindowState::Minimized)) {
+#ifdef KDDW_FRONTEND_QT_WINDOWS
+            // Workaround for WM_NCCALCSIZE not being honoured if directly minimized
+            view()->window()->setHasBeenMinimizedDirectlyFromRestore(true);
+#endif
             view()->showMinimized();
         } else {
             view()->showNormal();

--- a/src/core/WidgetResizeHandler.cpp
+++ b/src/core/WidgetResizeHandler.cpp
@@ -396,6 +396,12 @@ bool WidgetResizeHandler::handleWindowsNativeEvent(Core::Window::Ptr w, MSG *msg
                                                    const NativeFeatures &features)
 {
     if (msg->message == WM_NCCALCSIZE && features.hasShadow()) {
+        if (w->windowState() == WindowState::Minimized && w->hasBeenMinimizedDirectlyFromRestore()) {
+            // Qt is buggy with custom WM_NCCALCSIZE if window is minimized.
+            // Use full frame when minimized. We'll trigger WM_NCCALCSIZE when un-minimized.
+            return false;
+        }
+
         *result = 0;
         return true;
     } else if (msg->message == WM_NCHITTEST && (features.hasResize() || features.hasDrag())) {
@@ -652,7 +658,6 @@ void WidgetResizeHandler::setupWindow(Core::Window::Ptr window)
 {
     // Does some minor setup on our QWindow.
     // Like adding the drop shadow on Windows and two other workarounds.
-
 #ifdef KDDW_FRONTEND_QT_WINDOWS
     if (KDDockWidgets::usesAeroSnapWithCustomDecos()) {
         const auto wid = HWND(window->handle());

--- a/src/core/Window_p.h
+++ b/src/core/Window_p.h
@@ -155,6 +155,15 @@ public:
     /// Multiple callbacks can be registered
     virtual void onScreenChanged(Core::Object *context, WindowScreenChangedCallback) = 0;
 
+    /// Restoring a QWindow directly with showMinimized() is buggy on Qt on Windows, due to WM_NCCALCSIZE not handled correctly
+    virtual void setHasBeenMinimizedDirectlyFromRestore(bool)
+    {
+    }
+    virtual bool hasBeenMinimizedDirectlyFromRestore() const
+    {
+        return false;
+    }
+
 private:
     bool containsView(Controller *) const;
     bool containsView(View *) const;

--- a/src/qtcommon/Window.cpp
+++ b/src/qtcommon/Window.cpp
@@ -65,6 +65,17 @@ void Window::setProperty(const char *name, const QVariant &value)
     m_window->setProperty(name, value);
 }
 
+static const char *const s_kddw_hasBeenMinimizedDirectlyFromRestore = "kddw_hasBeenMinimizedDirectlyFromRestore";
+void Window::setHasBeenMinimizedDirectlyFromRestore(bool has)
+{
+    setProperty(s_kddw_hasBeenMinimizedDirectlyFromRestore, has);
+}
+
+bool Window::hasBeenMinimizedDirectlyFromRestore() const
+{
+    return property(s_kddw_hasBeenMinimizedDirectlyFromRestore).toBool();
+}
+
 bool Window::isVisible() const
 {
     return m_window->isVisible();

--- a/src/qtcommon/Window_p.h
+++ b/src/qtcommon/Window_p.h
@@ -40,6 +40,8 @@ public:
     void setProperty(const char *name, const QVariant &value);
     QVariant property(const char *name) const;
 
+    void setHasBeenMinimizedDirectlyFromRestore(bool) override;
+    bool hasBeenMinimizedDirectlyFromRestore() const override;
     bool equals(std::shared_ptr<Core::Window> other) const override;
     void setFramePosition(QPoint targetPos) override;
     void resize(int width, int height) override;

--- a/src/qtquick/views/FloatingWindow.cpp
+++ b/src/qtquick/views/FloatingWindow.cpp
@@ -252,8 +252,16 @@ Core::Item *FloatingWindow::rootItem() const
 
 void FloatingWindow::onWindowStateChanged(Qt::WindowState state)
 {
-    m_controller->setLastWindowManagerState(WindowState(state));
+    const auto newState = WindowState(state);
+    m_controller->setLastWindowManagerState(newState);
     m_controller->dptr()->windowStateChanged.emit();
+#if defined(Q_OS_WIN)
+    if (window()->hasBeenMinimizedDirectlyFromRestore() && newState != WindowState::Minimized) {
+        window()->setHasBeenMinimizedDirectlyFromRestore(false);
+        // restore our nice frames
+        WidgetResizeHandler::requestNCCALCSIZE(HWND(window()->handle()));
+    }
+#endif
 }
 
 #include "FloatingWindow.moc"


### PR DESCRIPTION
If LayoutSaver restored a window directly to a minimized state Qt would screw the custom window margins when showing the window again.

Workaround by not having custom frames in minimized mode, forcing Qt to honouring the new WM_NCCALCSIZE request when showing normal.