### PR TITLE
Wayland: Fix it being possible to drag group into itself

### DIFF
--- a/src/core/WindowBeingDragged.cpp
+++ b/src/core/WindowBeingDragged.cpp
@@ -247,6 +247,7 @@ WindowBeingDraggedWayland::WindowBeingDraggedWayland(Draggable *draggable)
     } else if (auto tabBar = draggable->asView()->asTabBarController()) {
         if (Platform::instance()->isQtWidgets())
             m_dockWidget = tabBar->currentDockWidget();
+        m_group = tabBar->group();
     } else if (auto stack = draggable->asView()->asStackController()) {
         if (Platform::instance()->isQtWidgets())
             m_group = stack->group();


### PR DESCRIPTION
It is possible to drag a group onto itself if one drags using the tabbar.