### PR TITLE
cmake: Require spdlog in developer mode

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -35,7 +35,7 @@ RUN apt update
 RUN apt install build-essential software-properties-common lld git cmake ninja-build \
                 mesa-common-dev libglu1-mesa-dev libglib2.0-dev libfontconfig \
                 libxkbcommon-dev mesa-utils libgl1-mesa-dev libglu1-mesa-dev \
-                vim clang-tidy-14 valgrind pip libxslt-dev llvm -y
+                vim clang-tidy-14 valgrind pip libxslt-dev llvm libspdlog-dev -y
 
 RUN pip install shiboken6-generator==6.6.0 shiboken6==6.6.0 pyside6==6.6.0
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,12 @@ jobs:
           sudo apt update -qq
           echo ${{ join(matrix.preset.apt_pgks, ' ') }} | xargs sudo apt install -y
 
+      # Not using apt_pgks, since spdlog is needed for all configurations:
+      - name: Install spdlog on Ubuntu
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          sudo apt install libspdlog-dev -y
+
       - name: Install Python dependencies (${{ join(matrix.preset.pip_pgks, ' ') }})
         if: ${{ matrix.preset.pip_pgks }}
         run: echo ${{ join(matrix.preset.pip_pgks, ' ') }} | xargs pip install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,8 +286,17 @@ if(NOT WIN32
 endif()
 
 if(NOT KDDockWidgets_NO_SPDLOG)
-    find_package(spdlog 1.8.0 QUIET)
-    find_package(fmt QUIET)
+    if(KDDockWidgets_DEVELOPER_MODE AND LINUX)
+        # Make sure we have at least one CI configuration running tests with spdlog enabled.
+        # Our tests are log error free. Any error printed should result in a fatal failure.
+        # For that we want spdlog enabled.
+        find_package(spdlog 1.8.0 REQUIRED)
+        find_package(fmt REQUIRED)
+    else()
+        # For regular user builds we don't care if people use it or not.
+        find_package(spdlog 1.8.0 QUIET)
+        find_package(fmt QUIET)
+    endif()
 endif()
 
 if(spdlog_FOUND AND fmt_FOUND)

--- a/src/core/spdlog_formatters_p.h
+++ b/src/core/spdlog_formatters_p.h
@@ -125,15 +125,15 @@ struct fmt::formatter<QFlags<F>>
 
 namespace KDDockWidgets {
 template<typename Enum, typename std::enable_if<std::is_enum<Enum>::value, int>::type = 0>
-constexpr auto format_as(Enum e) noexcept -> fmt::underlying_t<Enum>
+constexpr auto format_as(Enum e) noexcept -> typename std::underlying_type<Enum>::type
 {
-    return static_cast<fmt::underlying_t<Enum>>(e);
+    return static_cast<typename std::underlying_type<Enum>::type>(e);
 }
 namespace Core {
 template<typename Enum, fmt::enable_if_t<std::is_enum<Enum>::value, int> = 0>
-constexpr auto format_as(Enum e) noexcept -> fmt::underlying_t<Enum>
+constexpr auto format_as(Enum e) noexcept -> typename std::underlying_type<Enum>::type
 {
-    return static_cast<fmt::underlying_t<Enum>>(e);
+    return static_cast<typename std::underlying_type<Enum>::type>(e);
 }
 }
 }


### PR DESCRIPTION
Tests are warning/error free and will abort if one is ever printed. spdlog is optional for user builds, but no reason to make it optional for tests