### PR TITLE
Overwrite PATH in CMakeUserPresets-example.json

### DIFF
--- a/CMakeUserPresets-example.json
+++ b/CMakeUserPresets-example.json
@@ -8,6 +8,9 @@
             "cacheVariables": {
                 "CMAKE_PREFIX_PATH": "/data/installation/qt/qt6-dev/"
             },
+            "environment": {
+                "PATH": "$penv{PATH}"
+            },
             "inherits": [
                 "dev6"
             ]
@@ -18,6 +21,9 @@
             "description": "Preset which hardcodes Qt location instead of relying on PATH",
             "cacheVariables": {
                 "CMAKE_PREFIX_PATH": "/data/installation/qt/qt6-dev/"
+            },
+            "environment": {
+                "PATH": "$penv{PATH}"
             },
             "inherits": [
                 "dev-asan6"


### PR DESCRIPTION
Without overwriting the PATH here, we will prepend "/bin:" to the PATH variable because in both dev6 and dev-asan6 we've got the following:

```
"environment": {
    "PATH": "$env{QT6_DIR}/bin:$penv{PATH}"
},
```

Which in the absence of QT6_DIR will prepend a bogus entry to PATH. It's not much of a problem on Linux because "/bin" is in the path anyway. But on Windows, it messes up the PATH completely. Windows uses ";" as PATH separator.

With this change, we overwrite the PATH in the user preset example making sure that it's not messed up. After all, the idea of these examples is that we rely on CMAKE_PREFIX_PATH to locate Qt and not on QT6_DIR.

I would even argue that we shouldn't modify PATH in dev6 and dev-asan6 as well since they set CMAKE_PREFIX_PATH which should be sufficient to do the compilation.