### PR TITLE
.pre-commit-config.yaml - roll back to clang-format v17

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 ci:
-    skip: [pylint]
+    skip: [pylint,clang-format]
     autoupdate_schedule: monthly
 
 exclude: ^(cmake/ECM|cmake/KDAB/|src/3rdparty/|code.dev.code-workspace)
@@ -21,7 +21,7 @@ repos:
   - id: destroyed-symlinks
   - id: check-executables-have-shebangs
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v18.1.2
+  rev: v17.0.6
   hooks:
   - id: clang-format
     exclude: (.json)

--- a/src/core/Position.cpp
+++ b/src/core/Position.cpp
@@ -198,7 +198,7 @@ LayoutSaver::Position Position::serialize() const
             p.indexOfFloatingWindow = fw->beingDeleted()
                 ? -1
                 : DockRegistry::self()->floatingWindows().indexOf(
-                      fw);
+                    fw);
         } else {
             p.mainWindowUniqueName = mainWindow->uniqueName();
             assert(!p.mainWindowUniqueName.isEmpty());

--- a/src/core/Separator.cpp
+++ b/src/core/Separator.cpp
@@ -100,7 +100,7 @@ Separator::Separator(LayoutingHost *host, Qt::Orientation orientation, Core::Ite
     view()->show();
     view()->init();
     d->lazyResizeRubberBand = d->usesLazyResize ? Config::self().viewFactory()->createRubberBand(
-                                                      rubberBandIsTopLevel() ? nullptr : view())
+                                  rubberBandIsTopLevel() ? nullptr : view())
                                                 : nullptr;
     setVisible(true);
 }

--- a/src/core/TitleBar.cpp
+++ b/src/core/TitleBar.cpp
@@ -41,8 +41,8 @@ using namespace KDDockWidgets::Core;
 
 TitleBar::TitleBar(Group *parent)
     : Controller(
-          ViewType::TitleBar,
-          Config::self().viewFactory()->createTitleBar(this, parent ? parent->view() : nullptr))
+        ViewType::TitleBar,
+        Config::self().viewFactory()->createTitleBar(this, parent ? parent->view() : nullptr))
     , Draggable(view())
     , d(new Private())
     , m_group(parent)
@@ -67,8 +67,8 @@ TitleBar::TitleBar(Group *parent)
 
 TitleBar::TitleBar(FloatingWindow *parent)
     : Controller(
-          ViewType::TitleBar,
-          Config::self().viewFactory()->createTitleBar(this, parent ? parent->view() : nullptr))
+        ViewType::TitleBar,
+        Config::self().viewFactory()->createTitleBar(this, parent ? parent->view() : nullptr))
     , Draggable(view())
     , d(new Private())
     , m_group(nullptr)

--- a/tests/core/tst_dockwidget.cpp
+++ b/tests/core/tst_dockwidget.cpp
@@ -52,7 +52,7 @@ KDDW_QCORO_TASK tst_setGuestView()
     CHECK(dw->guestView());
     CHECK(dw->view());
     dw->view()->show();
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(500);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(500);
 
     CHECK(guest->controller());
     CHECK(dw->floatingWindow());
@@ -187,7 +187,7 @@ KDDW_QCORO_TASK tst_dwCloseAndReopen()
     }
 
     // 1 event loop for DelayedDelete. Avoids LSAN warnings.
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(1);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(1);
 
     KDDW_TEST_RETURN(true);
 }
@@ -203,7 +203,7 @@ KDDW_QCORO_TASK tst_setSize()
     }
 
     // 1 event loop for DelayedDelete. Avoids LSAN warnings.
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(1);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(1);
 
     KDDW_TEST_RETURN(true);
 }

--- a/tests/core/tst_droparea.cpp
+++ b/tests/core/tst_droparea.cpp
@@ -54,7 +54,7 @@ KDDW_QCORO_TASK tst_addWidgetHidden()
 
     auto group = dw->dptr()->group();
     delete dw;
-    KDDW_CO_AWAIT Core::Platform::instance() -> tests_waitForDeleted(group);
+    KDDW_CO_AWAIT Core::Platform::instance()->tests_waitForDeleted(group);
 
     KDDW_TEST_RETURN(true);
 }

--- a/tests/core/tst_floatingwindow.cpp
+++ b/tests/core/tst_floatingwindow.cpp
@@ -38,7 +38,7 @@ KDDW_QCORO_TASK tst_floatingWindowCtor()
     CHECK(dw->floatingWindow());
 
     /// Wait for FloatingWindow to be created
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(100);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(100);
 
     auto rootView = dw->view()->rootView();
     CHECK(rootView);

--- a/tests/core/tst_tabbar.cpp
+++ b/tests/core/tst_tabbar.cpp
@@ -205,7 +205,7 @@ KDDW_QCORO_TASK tst_tabBarDWClosed()
     }
 
     // 1 event loop for DelayedDelete. Avoids LSAN warnings.
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(1);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(1);
 
     KDDW_TEST_RETURN(true);
 }

--- a/tests/qtquick/tst_qtquick.cpp
+++ b/tests/qtquick/tst_qtquick.cpp
@@ -209,7 +209,7 @@ void TestQtQuick::tst_isFloatingIsEmitted()
     }
 
     // 1 event loop for DelayedDelete. Avoids LSAN warnings.
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(1);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(1);
 }
 
 void TestQtQuick::tst_shutdownCrash()
@@ -304,7 +304,7 @@ void TestQtQuick::tst_childQmlContext()
     }
 
     // 1 event loop for DelayedDelete. Avoids LSAN warnings.
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(1);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(1);
 }
 
 void TestQtQuick::tst_focusBetweenTabs()
@@ -321,7 +321,7 @@ void TestQtQuick::tst_focusBetweenTabs()
     auto floatingDock = DockRegistry::self()->dockByName("floatingDock");
 
     dock1->view()->rootView()->activateWindow();
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(2000);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(2000);
     dock1->dptr()->group()->focus();
 
     QVERIFY(dock1->isFocused());

--- a/tests/qtwidgets/tst_qtwidgets.cpp
+++ b/tests/qtwidgets/tst_qtwidgets.cpp
@@ -2361,14 +2361,14 @@ void TestQtWidgets::tst_focusBetweenTabs()
     leFloating->setFocus();
     QVERIFY(dock3->dockWidget()->isCurrentTab());
     m1->view()->activateWindow();
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(1);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(1);
     le3->setFocus();
 
     QVERIFY(le3->hasFocus());
     dock2->setAsCurrentTab();
     QVERIFY(dock2->dockWidget()->isCurrentTab());
     le2->setFocus();
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(1);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(1);
     QVERIFY(le2->hasFocus());
 
     // 2. Now, cycling tabs should toggle focus between le2 and le3
@@ -2394,7 +2394,7 @@ void TestQtWidgets::tst_focusBetweenTabs()
     auto titlebarFloating = floatingDock->actualTitleBar()->view();
     QVERIFY(titlebarFloating->isVisible());
     titlebarFloating->setFocus(Qt::MouseFocusReason);
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(1000);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(1000);
 
     QVERIFY(leFloating->hasFocus());
     QVERIFY(!le1->hasFocus());

--- a/tests/tst_docks.cpp
+++ b/tests/tst_docks.cpp
@@ -280,7 +280,7 @@ KDDW_QCORO_TASK tst_hasPreviousDockedLocation2()
     }
 
     // To process 1 event loop and do some delete later. Makes asan happy.
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(1);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(1);
 
     KDDW_TEST_RETURN(true);
 }
@@ -398,7 +398,7 @@ KDDW_QCORO_TASK tst_detachPos()
 
     const int previousWidth = dock1->width();
     dock1->setFloating(true);
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(400); // Needed for QtQuick
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(400); // Needed for QtQuick
 
     CHECK(std::abs(previousWidth - dock1->width()) < 15); // 15px of difference when floating is fine,
                                                           // due to margins and what not.
@@ -413,7 +413,7 @@ KDDW_QCORO_TASK tst_floatingWindowSize()
     auto dock1 = createDockWidget("1");
     auto fw1 = dock1->window();
 
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(100);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(100);
 
     CHECK(!fw1->geometry().isNull());
     CHECK_EQ(fw1->size(), fw1->window()->size());
@@ -475,7 +475,7 @@ KDDW_QCORO_TASK tst_sizeAfterRedock()
     const int height2 = dw2->dptr()->group()->height();
 
     dw2->setFloating(true);
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(100);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(100);
 
     CHECK_EQ(height2, dw2->window()->height());
     auto oldFw2 = dw2->floatingWindow();
@@ -987,11 +987,11 @@ KDDW_QCORO_TASK tst_maximizeAndRestore()
     CHECK(dropArea->checkSanity());
 
     m->view()->showMaximized();
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForResize(m->view());
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForResize(m->view());
 
     CHECK(dropArea->checkSanity());
     m->view()->showNormal();
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForResize(m->view());
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForResize(m->view());
 
     CHECK(dropArea->checkSanity());
 
@@ -1063,14 +1063,14 @@ KDDW_QCORO_TASK tst_invalidAnchorGroup()
         nestDockWidget(dock1, fw->dropArea(), nullptr, KDDockWidgets::Location_OnTop);
 
         dock1->close();
-        KDDW_CO_AWAIT Platform::instance() -> tests_waitForResize(dock2->view());
+        KDDW_CO_AWAIT Platform::instance()->tests_waitForResize(dock2->view());
         auto layout = fw->dropArea();
         layout->checkSanity();
 
         dock2->close();
         dock1->destroyLater();
         dock2->destroyLater();
-        KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(dock1);
+        KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(dock1);
     }
 
     {
@@ -1090,7 +1090,7 @@ KDDW_QCORO_TASK tst_invalidAnchorGroup()
 
         dock1->destroyLater();
         dock2->destroyLater();
-        KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(dock1);
+        KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(dock1);
     }
     KDDW_TEST_RETURN(true);
 }
@@ -1105,7 +1105,7 @@ KDDW_QCORO_TASK tst_doubleScheduleDelete()
     dock1->dptr()->group()->scheduleDeleteLater();
     dock1->dptr()->group()->scheduleDeleteLater();
 
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(100);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(100);
 
     KDDW_TEST_RETURN(true);
 }
@@ -1158,7 +1158,7 @@ KDDW_QCORO_TASK tst_addAsPlaceholder()
 
     // Cleanup
     dock2->destroyLater();
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(dock2);
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(dock2);
     KDDW_TEST_RETURN(true);
 }
 
@@ -1244,11 +1244,11 @@ KDDW_QCORO_TASK tst_removeItem()
 
     auto group2 = dock2->dptr()->group();
     dock2->close();
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(group2);
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(group2);
 
     auto group3 = dock3->dptr()->group();
     dock3->close();
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(group3);
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(group3);
 
     // The second anchor is now following the 3rd, while the 3rd is following 'bottom'
     layout->removeItem(dock3->dptr()->lastPosition()->lastItem()); // will trigger the 3rd anchor to
@@ -1260,7 +1260,7 @@ KDDW_QCORO_TASK tst_removeItem()
     dock1->destroyLater();
     dock2->destroyLater();
     dock3->destroyLater();
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(dock3);
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(dock3);
     KDDW_TEST_RETURN(true);
 }
 
@@ -1332,7 +1332,7 @@ KDDW_QCORO_TASK tst_startClosed()
     m->addDockWidget(dock1, Location_OnTop);
     Core::Group *group1 = dock1->dptr()->group();
     dock1->close();
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(group1);
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(group1);
 
     CHECK_EQ(layout->count(), 1);
     CHECK_EQ(layout->placeholderCount(), 1);
@@ -1406,7 +1406,7 @@ KDDW_QCORO_TASK tst_refUnrefItem()
 
     // 1. Delete a dock widget directly. It should delete its group and also the Item
     delete dock1;
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(group1);
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(group1);
     CHECK(!group1.data());
     CHECK(!item1.data());
 
@@ -1423,7 +1423,7 @@ KDDW_QCORO_TASK tst_refUnrefItem()
     // 3. Close dock2. group2 should be deleted, but item2 preserved.
     CHECK_EQ(item2->refCount(), 2);
     dock2->close();
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(group2);
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(group2);
     CHECK(dock2);
     CHECK(item2.data());
     CHECK_EQ(item2->refCount(), 1);
@@ -1441,7 +1441,7 @@ KDDW_QCORO_TASK tst_refUnrefItem()
     ObjectGuard<Core::Group> group4 = dock4->dptr()->group();
     ObjectGuard<Item> item4 = layout->itemForGroup(group4);
     dock4->close();
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(group4);
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(group4);
     CHECK_EQ(item4->refCount(), 1);
     CHECK(item4->isPlaceholder());
     layout->checkSanity();
@@ -1506,7 +1506,7 @@ KDDW_QCORO_TASK tst_placeholderCount()
     CHECK_EQ(layout->placeholderCount(), 0);
     layout->checkSanity();
 
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(fw);
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(fw);
     KDDW_TEST_RETURN(true);
 }
 
@@ -1570,7 +1570,7 @@ KDDW_QCORO_TASK tst_setAsCurrentTab()
 
     delete dock1;
     delete dock2;
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(fw);
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(fw);
     KDDW_TEST_RETURN(true);
 }
 
@@ -1663,7 +1663,7 @@ KDDW_QCORO_TASK tst_floatMaintainsSize()
     dw1->open();
 
     dw2->setFloating(true);
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(100);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(100);
 
     CHECK(std::abs(dw2->width() - oldWidth2) < 16); // 15px for margins
     KDDW_TEST_RETURN(true);
@@ -1821,7 +1821,7 @@ KDDW_QCORO_TASK tst_closeAllDockWidgets()
     DockRegistry::self()->clear();
     layout->checkSanity();
 
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(fw);
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(fw);
     CHECK(!fw);
 
     CHECK(dock1->window()->equals(dock1->view()));
@@ -2092,7 +2092,7 @@ KDDW_QCORO_TASK tst_setFloatingWhenWasTabbed()
     m->addDockWidgetAsTab(dock3);
     m->destroyLater();
     auto window = m.release();
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(window);
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(window);
     KDDW_TEST_RETURN(true);
 }
 
@@ -2177,9 +2177,9 @@ KDDW_QCORO_TASK tst_posAfterLeftDetach()
         EnsureTopLevelsDeleted e;
         auto fw = createFloatingWindow();
         auto dock2 = createDockWidget("doc2");
-        KDDW_CO_AWAIT Platform::instance() -> tests_wait(100);
+        KDDW_CO_AWAIT Platform::instance()->tests_wait(100);
         nestDockWidget(dock2, fw->dropArea(), nullptr, KDDockWidgets::Location_OnRight);
-        KDDW_CO_AWAIT Platform::instance() -> tests_wait(100);
+        KDDW_CO_AWAIT Platform::instance()->tests_wait(100);
         CHECK(fw->dropArea()->checkSanity());
         // When dragging the right one there was a bug where it jumped
         const Point globalSrc = dock2->mapToGlobal(Point(0, 0));
@@ -2188,7 +2188,7 @@ KDDW_QCORO_TASK tst_posAfterLeftDetach()
         CHECK(dock2->isVisible());
 
         // Flutter is a bit slower showing stuff, needs 1 event loop
-        KDDW_CO_AWAIT Platform::instance() -> tests_wait(100);
+        KDDW_CO_AWAIT Platform::instance()->tests_wait(100);
 
         KDDW_CO_AWAIT drag(dock2->view(), globalDest);
         CHECK(fw->dropArea()->checkSanity());
@@ -2200,7 +2200,7 @@ KDDW_QCORO_TASK tst_posAfterLeftDetach()
 
         delete dock2;
         fw->destroyLater();
-        KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(fw);
+        KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(fw);
     }
 
     {
@@ -2218,7 +2218,7 @@ KDDW_QCORO_TASK tst_posAfterLeftDetach()
 
         delete dock2;
         fw->destroyLater();
-        KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(fw);
+        KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(fw);
     }
     KDDW_TEST_RETURN(true);
 }
@@ -2322,7 +2322,7 @@ KDDW_QCORO_TASK tst_addAndReadd()
 
     // Cleanup
     delete dock1;
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(fw);
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(fw);
     KDDW_TEST_RETURN(true);
 }
 
@@ -2338,7 +2338,7 @@ KDDW_QCORO_TASK tst_addToSmallMainWindow1()
     const int mainWindowLength = 400;
 
     m->view()->window()->resize(mainWindowLength, mainWindowLength);
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(100);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(100);
 
     dock1->view()->resize(Size(800, 800));
     dock2->view()->resize(Size(800, 800));
@@ -2349,7 +2349,7 @@ KDDW_QCORO_TASK tst_addToSmallMainWindow1()
 
     CHECK_EQ(m->height(), mainWindowLength);
 
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(300);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(300);
     if (dock1->height() > mainWindowLength) {
         KDDW_INFO("dock1->height={} ; mainWindowLength={}", dock1->height(), mainWindowLength);
         CHECK(false);
@@ -2383,7 +2383,7 @@ KDDW_QCORO_TASK tst_addToSmallMainWindow2()
     m->addDockWidgetAsTab(dock1);
     m->view()->window()->resize(osWindowMinWidth(), 200);
 
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForResize(m->view());
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForResize(m->view());
 
     CHECK(std::abs(m->width() - osWindowMinWidth()) < 30); // Not very important verification. Anyway,
                                                            // using 15 to account for margins and what
@@ -2392,7 +2392,7 @@ KDDW_QCORO_TASK tst_addToSmallMainWindow2()
     if (Platform::instance()->isQtWidgets())
         CHECK(KDDW_CO_AWAIT Platform::instance()->tests_waitForResize(m.get()));
     else
-        KDDW_CO_AWAIT Platform::instance() -> tests_wait(100);
+        KDDW_CO_AWAIT Platform::instance()->tests_wait(100);
 
 
     CHECK(dropArea->layoutWidth() > osWindowMinWidth());
@@ -2413,7 +2413,7 @@ KDDW_QCORO_TASK tst_addToSmallMainWindow3()
         createDockWidget("dock2", Platform::instance()->tests_createView({ true, {}, { 0, 0 } }));
     m->addDockWidgetAsTab(dock1);
     m->view()->window()->resize(osWindowMinWidth(), 200);
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(200);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(200);
     CHECK(std::abs(m->width() - osWindowMinWidth()) < 15); // Not very important verification. Anyway,
                                                            // using 15 to account for margins and what
                                                            // not.
@@ -2432,7 +2432,7 @@ KDDW_QCORO_TASK tst_addToSmallMainWindow4()
     EnsureTopLevelsDeleted e;
     auto m = createMainWindow(Size(100, 100), MainWindowOption_None);
 
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(100);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(100);
     CHECK_EQ(m->height(), 100);
 
     auto dropArea = m->dropArea();
@@ -2442,10 +2442,10 @@ KDDW_QCORO_TASK tst_addToSmallMainWindow4()
         "dock2", Platform::instance()->tests_createView({ true, {}, Size(50, 50) }));
     Core::DropArea *layout = dropArea;
     m->addDockWidget(dock1, KDDockWidgets::Location_OnBottom);
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForResize(m->view());
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForResize(m->view());
 
     m->addDockWidget(dock2, KDDockWidgets::Location_OnBottom);
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForResize(m->view());
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForResize(m->view());
     CHECK(m->dropArea()->checkSanity());
 
     const int item2MinHeight =
@@ -2610,13 +2610,13 @@ KDDW_QCORO_TASK tst_resizeViaAnchorsAfterPlaceholderCreation()
         m->addDockWidget(dock1, Location_OnTop);
         CHECK_EQ(layout->separators().size(), 2);
         dock2->close();
-        KDDW_CO_AWAIT Platform::instance() -> tests_waitForResize(dock3->view());
+        KDDW_CO_AWAIT Platform::instance()->tests_waitForResize(dock3->view());
         CHECK_EQ(layout->separators().size(), 1);
         layout->checkSanity();
 
         // Cleanup:
         dock2->destroyLater();
-        KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(dock2);
+        KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(dock2);
     }
 
     {
@@ -2649,7 +2649,7 @@ KDDW_QCORO_TASK tst_resizeViaAnchorsAfterPlaceholderCreation()
         CHECK_EQ(boundToTheRight, expectedBoundToTheRight);
 
         dock3->close();
-        KDDW_CO_AWAIT Platform::instance() -> tests_waitForResize(dock2->view());
+        KDDW_CO_AWAIT Platform::instance()->tests_waitForResize(dock2->view());
 
         CHECK(!item1->isPlaceholder());
         CHECK(!item2->isPlaceholder());
@@ -2662,7 +2662,7 @@ KDDW_QCORO_TASK tst_resizeViaAnchorsAfterPlaceholderCreation()
 
         CHECK_EQ(boundToTheRight, expectedBoundToTheRight);
         dock3->destroyLater();
-        KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(dock3);
+        KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(dock3);
     }
     KDDW_TEST_RETURN(true);
 }
@@ -2713,7 +2713,7 @@ KDDW_QCORO_TASK tst_restoreAfterResize()
     if (oldContentsSize != layout->layoutSize()) {
         // Hard to reproduce but sometimes happens. Added a wait to see if it's timing related
         KDDW_INFO("tst_restoreAfterResize: Unexpected layout size={}, expected={}", layout->layoutSize(), oldContentsSize);
-        KDDW_CO_AWAIT Platform::instance() -> tests_wait(1000);
+        KDDW_CO_AWAIT Platform::instance()->tests_wait(1000);
         CHECK_EQ(oldContentsSize, layout->layoutSize());
     }
 
@@ -3142,7 +3142,7 @@ KDDW_QCORO_TASK tst_restoreWithDockFactory()
     CHECK(!saved.isEmpty());
     ObjectGuard<Core::Group> f1 = dock1->dptr()->group();
     delete dock1;
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(f1);
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(f1);
     CHECK(!f1);
 
     // Directly deleted don't leave placeolders. We could though.
@@ -3420,7 +3420,7 @@ KDDW_QCORO_TASK tst_setFloatingAfterDraggedFromTabToSideBySide()
         CHECK(!dock2->isFloating());
         CHECK(layout->checkSanity());
 
-        KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(fw2);
+        KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(fw2);
     }
     KDDW_TEST_RETURN(true);
 }
@@ -3454,7 +3454,7 @@ KDDW_QCORO_TASK tst_setFloatingAFrameWithTabs()
     CHECK_EQ(layout->placeholderCount(), 0);
     CHECK(dock1->window()->equals(m->view()));
 
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(fw);
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(fw);
     KDDW_TEST_RETURN(true);
 }
 
@@ -3472,7 +3472,7 @@ KDDW_QCORO_TASK tst_toggleDockWidgetWithHiddenTitleBar()
 
     d1->toggleAction()->setChecked(false);
     auto f1 = d1->dptr()->group();
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(f1);
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(f1);
     SetExpectedWarning expected("Trying to use a group that's being deleted");
     d1->toggleAction()->setChecked(true);
     CHECK(d1->dptr()->group());
@@ -3581,7 +3581,7 @@ KDDW_QCORO_TASK tst_anchorFollowingItselfAssert()
 
     docks.at(0).createdDock->destroyLater();
     docks.at(4).createdDock->destroyLater();
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(docks.at(4).createdDock);
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(docks.at(4).createdDock);
     KDDW_TEST_RETURN(true);
 }
 
@@ -3837,7 +3837,7 @@ KDDW_QCORO_TASK tst_sizeConstraintWarning()
     for (auto dock : docks)
         dock->destroyLater();
 
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(lastDock);
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(lastDock);
     KDDW_TEST_RETURN(true);
 }
 
@@ -3915,7 +3915,7 @@ KDDW_QCORO_TASK tst_dockNotFillingSpace()
     Core::Group *group2 = d2->dptr()->group();
     d1->close();
     d2->close();
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(group2);
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(group2);
 
     auto layout = m->multiSplitter();
     CHECK(layout->checkSanity());
@@ -3936,7 +3936,7 @@ KDDW_QCORO_TASK tst_lastFloatingPositionIsRestored()
     dock1->window()->window()->setFramePosition(targetPos);
     CHECK_EQ(dock1->window()->window()->frameGeometry().topLeft(), targetPos);
     auto oldFw = dock1->window();
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForEvent(dock1->window().get(), Event::Move);
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForEvent(dock1->window().get(), Event::Move);
 
     LayoutSaver saver;
     QByteArray saved = saver.serializeLayout();
@@ -4066,7 +4066,7 @@ KDDW_QCORO_TASK tst_floatingAction()
         CHECK(!dock1->isTabbed());
         CHECK_EQ(action->toolTip(), Object::tr("Detach"));
 
-        KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(fw);
+        KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(fw);
     }
 
     {
@@ -4109,7 +4109,7 @@ KDDW_QCORO_TASK tst_floatingAction()
         CHECK(!dock1->isTabbed());
         CHECK_EQ(action->toolTip(), Object::tr("Detach"));
 
-        KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(fw);
+        KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(fw);
     }
     {
         EnsureTopLevelsDeleted e;
@@ -4431,20 +4431,20 @@ KDDW_QCORO_TASK tst_dontCloseDockWidgetBeforeRestore4()
     m->addDockWidget(dock1, Location_OnBottom);
     m->addDockWidget(dock2, Location_OnBottom);
 
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(100);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(100);
     dock1->close();
     dock2->close();
 
     LayoutSaver saver;
     const QByteArray saved = saver.serializeLayout();
 
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(100);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(100);
     dock2->open();
 
     CHECK(saver.restoreLayout(saved));
     CHECK(dock2->isOpen());
 
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(100);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(100);
     Core::FloatingWindow *fw = dock2->floatingWindow();
     DropArea *da = fw->dropArea();
     CHECK(da->checkSanity());
@@ -4673,7 +4673,7 @@ KDDW_QCORO_TASK tst_maxSizedHonouredAfterRemoved()
     auto root = m1->multiSplitter()->rootItem();
 
     // Wait 1 event loop so we get layout invalidated and get max-size constraints
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(10);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(10);
 
     auto sep = root->separators().constFirst();
     root->requestEqualSize(sep); // Since we're not calling honourMaxSizes() after a widget changes
@@ -4694,7 +4694,7 @@ KDDW_QCORO_TASK tst_maxSizedHonouredAfterRemoved()
 
     // Close dock2 and check if dock1's max-size is still honoured
     dock2->close();
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(100); // wait for the resize, so dock1 gets taller"
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(100); // wait for the resize, so dock1 gets taller"
 
     CHECK(dock1->dptr()->group()->view()->height()
           <= dock1->dptr()->group()->view()->maxSizeHint().height());
@@ -4719,7 +4719,7 @@ KDDW_QCORO_TASK tst_addDockWidgetAsTabToDockWidget()
         CHECK_EQ(dock1->dptr()->group()->dockWidgetCount(), 2);
         dock1->destroyLater();
         dock2->destroyLater();
-        KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(dock2);
+        KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(dock2);
     }
     {
         // Dock into a morphed dock widget
@@ -4736,7 +4736,7 @@ KDDW_QCORO_TASK tst_addDockWidgetAsTabToDockWidget()
         CHECK_EQ(dock1->dptr()->group()->dockWidgetCount(), 2);
         dock1->destroyLater();
         dock2->destroyLater();
-        KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(dock2);
+        KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(dock2);
     }
     {
         // Dock a morphed dock widget into a morphed dock widget
@@ -4753,11 +4753,11 @@ KDDW_QCORO_TASK tst_addDockWidgetAsTabToDockWidget()
         CHECK_EQ(window1->window(), window2->window());
         CHECK_EQ(dock1->dptr()->group(), dock2->dptr()->group());
         CHECK_EQ(dock1->dptr()->group()->dockWidgetCount(), 2);
-        KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(originalWindow2.get());
+        KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(originalWindow2.get());
 
         dock1->destroyLater();
         dock2->destroyLater();
-        KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(dock2);
+        KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(dock2);
     }
     {
         // Dock to an already docked widget
@@ -4951,7 +4951,7 @@ KDDW_QCORO_TASK tst_constraintsAfterPlaceholder()
 
     // Now close dock1 and check again
     dock1->close();
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForResize(dock2->view());
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForResize(dock2->view());
 
     Item *item2 = layout->itemForGroup(dock2->dptr()->group());
     Item *item3 = layout->itemForGroup(dock3->dptr()->group());
@@ -4963,7 +4963,7 @@ KDDW_QCORO_TASK tst_constraintsAfterPlaceholder()
     CHECK_EQ(m->view()->minSize().height(), expectedMinHeight);
 
     dock1->destroyLater();
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(dock1);
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(dock1);
     KDDW_TEST_RETURN(true);
 }
 
@@ -4986,7 +4986,7 @@ KDDW_QCORO_TASK tst_dragBySingleTab()
     KDDW_CO_AWAIT drag(tabBar->view(), globalPressPos, Point(0, 0));
 
     delete dock1;
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(group1);
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(group1);
     KDDW_TEST_RETURN(true);
 }
 
@@ -5665,7 +5665,7 @@ KDDW_QCORO_TASK tst_maximizeButton()
 
     tb->onMaximizeClicked();
 
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForResize(dock0->floatingWindow()->view());
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForResize(dock0->floatingWindow()->view());
 
     CHECK(tb->maximizeButtonVisible());
     CHECK_EQ(tb->maximizeButtonType(), TitleBarButtonType::Normal);
@@ -5739,7 +5739,7 @@ KDDW_QCORO_TASK tst_map()
     m->addDockWidget(dockA, KDDockWidgets::Location_OnTop);
     m->addDockWidget(dockB, KDDockWidgets::Location_OnBottom);
 
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(1000);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(1000);
     const Point localPt = { 10, 10 };
     Point global = dockA->view()->mapToGlobal(localPt);
     CHECK_EQ(dockA->view()->mapFromGlobal(global), localPt);
@@ -5761,7 +5761,7 @@ KDDW_QCORO_TASK tst_childViewAt()
     m->addDockWidget(dockB, KDDockWidgets::Location_OnBottom);
     m->show();
 
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(1000);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(1000);
     const Point localPt = { 100, 200 };
     auto child = m->view()->childViewAt(localPt);
     CHECK(child);
@@ -5783,7 +5783,7 @@ KDDW_QCORO_TASK tst_resizeInLayout()
     m->addDockWidget(dockC, KDDockWidgets::Location_OnBottom);
 
     m->window()->resize(400, 1000);
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForResize(m->view());
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForResize(m->view());
 
     // Nothing happens, since the widget's top is the window's top too:
     const Size dockAOriginalSize = dockA->sizeInLayout();
@@ -5827,7 +5827,7 @@ KDDW_QCORO_TASK tst_resizeInLayout()
 KDDW_QCORO_TASK tst_keepLast()
 {
     // 1 event loop for DelayedDelete. Avoids LSAN warnings.
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(1);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(1);
     KDDW_TEST_RETURN(true);
 }
 
@@ -5990,170 +5990,171 @@ KDDW_QCORO_TASK tst_rect()
     KDDW_TEST_RETURN(true);
 }
 
-static const auto s_tests = std::vector<KDDWTest> {
+static const auto s_tests = std::vector<KDDWTest>
+{
     TEST(tst_simple1),
-    TEST(tst_simple2),
-    TEST(tst_resizeWindow2),
-    TEST(tst_hasPreviousDockedLocation),
-    TEST(tst_hasPreviousDockedLocation2),
-    TEST(tst_LayoutSaverOpenedDocks),
-    TEST(tst_ghostSeparator),
-    TEST(tst_detachFromMainWindow),
-    TEST(tst_floatingWindowSize),
-    TEST(tst_tabbingWithAffinities),
-    TEST(tst_floatingWindowTitleBug),
-    TEST(tst_setFloatingSimple),
-    TEST(tst_dragOverTitleBar),
-    TEST(tst_setFloatingGeometry),
-    TEST(tst_restoreEmpty),
-    TEST(tst_restoreCentralFrame),
-    TEST(tst_restoreNonExistingDockWidget),
-    TEST(tst_shutdown),
-    TEST(tst_closeDockWidgets),
-    TEST(tst_closeReason),
-    TEST(tst_layoutEqually),
-    TEST(tst_doubleClose),
-    TEST(tst_maximizeAndRestore),
-    TEST(tst_restoreWithNonClosableWidget),
-    TEST(tst_restoreCrash),
-    TEST(tst_restoreSideBySide),
-    TEST(tst_restoreWithCentralFrameWithTabs),
-    TEST(tst_restoreGroupOptions),
-    TEST(tst_restoreWithAffinity),
-    TEST(tst_marginsAfterRestore),
-    TEST(tst_restoreWithNewDockWidgets),
-    TEST(tst_restoreWithDockFactory),
-    TEST(tst_restoreWithDockFactory2),
-    TEST(tst_dontCloseDockWidgetBeforeRestore),
-    TEST(tst_dontCloseDockWidgetBeforeRestore3),
-    TEST(tst_dontCloseDockWidgetBeforeRestore4),
-    TEST(tst_skipRestoreInsideMainWindow),
-    TEST(tst_restoreWithNativeTitleBar),
-    TEST(tst_closeOnlyCurrentTab),
-    TEST(tst_tabWidgetCurrentIndex),
-    TEST(tst_propagateResize2),
-    TEST(tst_startClosed),
-    TEST(tst_closeReparentsToNull),
-    TEST(tst_invalidAnchorGroup),
-    TEST(tst_addAsPlaceholder),
-    TEST(tst_repeatedShowHide),
-    TEST(tst_removeItem),
-    TEST(tst_clear),
-    TEST(tst_crash),
-    TEST(tst_refUnrefItem),
-    TEST(tst_placeholderCount),
-    TEST(tst_availableLengthForOrientation),
-    TEST(tst_closeTabOfCentralFrame),
-    TEST(tst_centralGroupAffinity),
-    TEST(tst_setAsCurrentTab),
-    TEST(tst_placeholderDisappearsOnReadd),
-    TEST(tst_placeholdersAreRemovedProperly),
-    TEST(tst_preferredInitialSize),
-    TEST(tst_closeAllDockWidgets),
-    TEST(tst_toggleMiddleDockCrash),
-    TEST(tst_stealFrame),
-    TEST(tst_setFloatingWhenWasTabbed),
-    TEST(tst_setWidget),
-    TEST(tst_floatingLastPosAfterDoubleClose),
-    TEST(tst_registry),
-    TEST(tst_honourGeometryOfHiddenWindow),
-    TEST(tst_posAfterLeftDetach),
-    TEST(tst_propagateMinSize),
-    TEST(tst_createFloatingWindow),
-    TEST(tst_fairResizeAfterRemoveWidget),
-    TEST(tst_unfloatTabbedFloatingWidgets),
-    TEST(tst_unfloatTabbedFloatingWidgets2),
-    TEST(tst_resizeViaAnchorsAfterPlaceholderCreation),
-    TEST(tst_rectForDropCrash),
-    TEST(tst_addDockWidgetToMainWindow),
-    TEST(tst_addDockWidgetToContainingWindow),
-    TEST(tst_setFloatingAfterDraggedFromTabToSideBySide),
-    TEST(tst_setFloatingAFrameWithTabs),
-    TEST(tst_toggleDockWidgetWithHiddenTitleBar),
-    TEST(tst_anchorFollowingItselfAssert),
-    TEST(tst_isInMainWindow),
-    TEST(tst_sizeConstraintWarning),
-    TEST(tst_stuckSeparator),
-    TEST(tst_dockNotFillingSpace),
-    TEST(tst_titlebar_getter),
-    TEST(tst_addingOptionHiddenTabbed),
-    TEST(tst_maxSizedHonouredAfterRemoved),
-    TEST(tst_addDockWidgetAsTabToDockWidget),
-    TEST(tst_closeTabHidesDockWidget),
-    TEST(tst_propagateSizeHonoursMinSize),
-    TEST(tst_floatingAction),
-    TEST(tst_constraintsPropagateUp),
-    TEST(tst_addToSmallMainWindow4),
-    TEST(tst_addToSmallMainWindow5),
-    TEST(tst_dragBySingleTab),
-    TEST(tst_deleteOnClose),
-    TEST(tst_toggleAction),
-    TEST(tst_redocksToPreviousTabIndex),
-    TEST(tst_toggleTabbed2),
-    TEST(tst_resizePropagatesEvenly),
-    TEST(tst_persistentCentralWidget),
-    TEST(tst_titlebarNumDockWidgetsChanged),
-    TEST(tst_closed),
-    TEST(tst_restoreFlagsFromVersion16),
-    TEST(tst_map),
-    TEST(tst_childViewAt),
-    TEST(tst_detachPos),
-    TEST(tst_floatMaintainsSize),
-    TEST(tst_scopedValueRollback),
-    TEST(tst_size),
-    TEST(tst_point),
-    TEST(tst_rect),
-    TEST(tst_resizeInLayout),
-    TEST(tst_mainWindowToggle),
-    TEST(tst_startDragging),
+        TEST(tst_simple2),
+        TEST(tst_resizeWindow2),
+        TEST(tst_hasPreviousDockedLocation),
+        TEST(tst_hasPreviousDockedLocation2),
+        TEST(tst_LayoutSaverOpenedDocks),
+        TEST(tst_ghostSeparator),
+        TEST(tst_detachFromMainWindow),
+        TEST(tst_floatingWindowSize),
+        TEST(tst_tabbingWithAffinities),
+        TEST(tst_floatingWindowTitleBug),
+        TEST(tst_setFloatingSimple),
+        TEST(tst_dragOverTitleBar),
+        TEST(tst_setFloatingGeometry),
+        TEST(tst_restoreEmpty),
+        TEST(tst_restoreCentralFrame),
+        TEST(tst_restoreNonExistingDockWidget),
+        TEST(tst_shutdown),
+        TEST(tst_closeDockWidgets),
+        TEST(tst_closeReason),
+        TEST(tst_layoutEqually),
+        TEST(tst_doubleClose),
+        TEST(tst_maximizeAndRestore),
+        TEST(tst_restoreWithNonClosableWidget),
+        TEST(tst_restoreCrash),
+        TEST(tst_restoreSideBySide),
+        TEST(tst_restoreWithCentralFrameWithTabs),
+        TEST(tst_restoreGroupOptions),
+        TEST(tst_restoreWithAffinity),
+        TEST(tst_marginsAfterRestore),
+        TEST(tst_restoreWithNewDockWidgets),
+        TEST(tst_restoreWithDockFactory),
+        TEST(tst_restoreWithDockFactory2),
+        TEST(tst_dontCloseDockWidgetBeforeRestore),
+        TEST(tst_dontCloseDockWidgetBeforeRestore3),
+        TEST(tst_dontCloseDockWidgetBeforeRestore4),
+        TEST(tst_skipRestoreInsideMainWindow),
+        TEST(tst_restoreWithNativeTitleBar),
+        TEST(tst_closeOnlyCurrentTab),
+        TEST(tst_tabWidgetCurrentIndex),
+        TEST(tst_propagateResize2),
+        TEST(tst_startClosed),
+        TEST(tst_closeReparentsToNull),
+        TEST(tst_invalidAnchorGroup),
+        TEST(tst_addAsPlaceholder),
+        TEST(tst_repeatedShowHide),
+        TEST(tst_removeItem),
+        TEST(tst_clear),
+        TEST(tst_crash),
+        TEST(tst_refUnrefItem),
+        TEST(tst_placeholderCount),
+        TEST(tst_availableLengthForOrientation),
+        TEST(tst_closeTabOfCentralFrame),
+        TEST(tst_centralGroupAffinity),
+        TEST(tst_setAsCurrentTab),
+        TEST(tst_placeholderDisappearsOnReadd),
+        TEST(tst_placeholdersAreRemovedProperly),
+        TEST(tst_preferredInitialSize),
+        TEST(tst_closeAllDockWidgets),
+        TEST(tst_toggleMiddleDockCrash),
+        TEST(tst_stealFrame),
+        TEST(tst_setFloatingWhenWasTabbed),
+        TEST(tst_setWidget),
+        TEST(tst_floatingLastPosAfterDoubleClose),
+        TEST(tst_registry),
+        TEST(tst_honourGeometryOfHiddenWindow),
+        TEST(tst_posAfterLeftDetach),
+        TEST(tst_propagateMinSize),
+        TEST(tst_createFloatingWindow),
+        TEST(tst_fairResizeAfterRemoveWidget),
+        TEST(tst_unfloatTabbedFloatingWidgets),
+        TEST(tst_unfloatTabbedFloatingWidgets2),
+        TEST(tst_resizeViaAnchorsAfterPlaceholderCreation),
+        TEST(tst_rectForDropCrash),
+        TEST(tst_addDockWidgetToMainWindow),
+        TEST(tst_addDockWidgetToContainingWindow),
+        TEST(tst_setFloatingAfterDraggedFromTabToSideBySide),
+        TEST(tst_setFloatingAFrameWithTabs),
+        TEST(tst_toggleDockWidgetWithHiddenTitleBar),
+        TEST(tst_anchorFollowingItselfAssert),
+        TEST(tst_isInMainWindow),
+        TEST(tst_sizeConstraintWarning),
+        TEST(tst_stuckSeparator),
+        TEST(tst_dockNotFillingSpace),
+        TEST(tst_titlebar_getter),
+        TEST(tst_addingOptionHiddenTabbed),
+        TEST(tst_maxSizedHonouredAfterRemoved),
+        TEST(tst_addDockWidgetAsTabToDockWidget),
+        TEST(tst_closeTabHidesDockWidget),
+        TEST(tst_propagateSizeHonoursMinSize),
+        TEST(tst_floatingAction),
+        TEST(tst_constraintsPropagateUp),
+        TEST(tst_addToSmallMainWindow4),
+        TEST(tst_addToSmallMainWindow5),
+        TEST(tst_dragBySingleTab),
+        TEST(tst_deleteOnClose),
+        TEST(tst_toggleAction),
+        TEST(tst_redocksToPreviousTabIndex),
+        TEST(tst_toggleTabbed2),
+        TEST(tst_resizePropagatesEvenly),
+        TEST(tst_persistentCentralWidget),
+        TEST(tst_titlebarNumDockWidgetsChanged),
+        TEST(tst_closed),
+        TEST(tst_restoreFlagsFromVersion16),
+        TEST(tst_map),
+        TEST(tst_childViewAt),
+        TEST(tst_detachPos),
+        TEST(tst_floatMaintainsSize),
+        TEST(tst_scopedValueRollback),
+        TEST(tst_size),
+        TEST(tst_point),
+        TEST(tst_rect),
+        TEST(tst_resizeInLayout),
+        TEST(tst_mainWindowToggle),
+        TEST(tst_startDragging),
 #if !defined(KDDW_FRONTEND_FLUTTER)
-    TEST(tst_minMaxGuest),
-    TEST(tst_doesntHaveNativeTitleBar),
-    TEST(tst_sizeAfterRedock),
-    TEST(tst_honourUserGeometry),
-    TEST(tst_restoreMaximizedState),
-    TEST(tst_restoreFloatingMinimizedState),
-    TEST(tst_dockInternal),
-    TEST(tst_samePositionAfterHideRestore),
-    TEST(tst_restoreTwice),
-    TEST(tst_restoreAfterResize),
-    TEST(tst_restoreNestedAndTabbed),
-    TEST(tst_restoreWithPlaceholder),
-    TEST(tst_lastFloatingPositionIsRestored),
-    TEST(tst_restoreNonClosable),
-    TEST(tst_restoreNlohmanException),
-    TEST(tst_restoreWithInvalidCurrentTab),
-    TEST(tst_restoreRestoresMainWindowPosition),
-    TEST(tst_dontCloseDockWidgetBeforeRestore2),
-    TEST(tst_doubleClickTabToDetach),
-    TEST(tst_tabTitleChanges),
-    TEST(tst_preventClose),
-    TEST(tst_addAndReadd),
-    TEST(tst_notClosable),
-    TEST(tst_availableSizeWithPlaceholders),
-    TEST(tst_moreTitleBarCornerCases),
-    TEST(tst_raise),
-    TEST(tst_nonDockable),
-    TEST(tst_flagDoubleClick),
-    TEST(tst_constraintsAfterPlaceholder),
-    TEST(tst_addToSmallMainWindow1),
-    TEST(tst_addToSmallMainWindow2),
-    TEST(tst_addToSmallMainWindow3),
-    TEST(tst_titleBarFocusedWhenTabsChange),
-    TEST(tst_toggleTabbed),
-    TEST(tst_currentTabMatchesDockWidget),
-    TEST(tst_addMDIDockWidget),
-    TEST(tst_mdiZorder),
-    TEST(tst_mdiCrash),
-    TEST(tst_mdiZorder2),
-    TEST(tst_mdiSetSize),
-    TEST(tst_mixedMDIRestoreToArea),
-    TEST(tst_redockToMDIRestoresPosition),
-    TEST(tst_maximizeButton),
-    TEST(tst_restoreAfterUnminimized),
-    TEST(tst_doubleScheduleDelete),
+        TEST(tst_minMaxGuest),
+        TEST(tst_doesntHaveNativeTitleBar),
+        TEST(tst_sizeAfterRedock),
+        TEST(tst_honourUserGeometry),
+        TEST(tst_restoreMaximizedState),
+        TEST(tst_restoreFloatingMinimizedState),
+        TEST(tst_dockInternal),
+        TEST(tst_samePositionAfterHideRestore),
+        TEST(tst_restoreTwice),
+        TEST(tst_restoreAfterResize),
+        TEST(tst_restoreNestedAndTabbed),
+        TEST(tst_restoreWithPlaceholder),
+        TEST(tst_lastFloatingPositionIsRestored),
+        TEST(tst_restoreNonClosable),
+        TEST(tst_restoreNlohmanException),
+        TEST(tst_restoreWithInvalidCurrentTab),
+        TEST(tst_restoreRestoresMainWindowPosition),
+        TEST(tst_dontCloseDockWidgetBeforeRestore2),
+        TEST(tst_doubleClickTabToDetach),
+        TEST(tst_tabTitleChanges),
+        TEST(tst_preventClose),
+        TEST(tst_addAndReadd),
+        TEST(tst_notClosable),
+        TEST(tst_availableSizeWithPlaceholders),
+        TEST(tst_moreTitleBarCornerCases),
+        TEST(tst_raise),
+        TEST(tst_nonDockable),
+        TEST(tst_flagDoubleClick),
+        TEST(tst_constraintsAfterPlaceholder),
+        TEST(tst_addToSmallMainWindow1),
+        TEST(tst_addToSmallMainWindow2),
+        TEST(tst_addToSmallMainWindow3),
+        TEST(tst_titleBarFocusedWhenTabsChange),
+        TEST(tst_toggleTabbed),
+        TEST(tst_currentTabMatchesDockWidget),
+        TEST(tst_addMDIDockWidget),
+        TEST(tst_mdiZorder),
+        TEST(tst_mdiCrash),
+        TEST(tst_mdiZorder2),
+        TEST(tst_mdiSetSize),
+        TEST(tst_mixedMDIRestoreToArea),
+        TEST(tst_redockToMDIRestoresPosition),
+        TEST(tst_maximizeButton),
+        TEST(tst_restoreAfterUnminimized),
+        TEST(tst_doubleScheduleDelete),
 #endif
-    TEST(tst_keepLast)
+        TEST(tst_keepLast)
 };
 
 #include "tests_main.h"

--- a/tests/tst_docks_slow1.cpp
+++ b/tests/tst_docks_slow1.cpp
@@ -72,14 +72,14 @@ KDDW_QCORO_TASK tst_invalidPlaceholderPosition()
         CHECK(!dock1->isOpen());
         CHECK(!dock1->view()->isVisible());
 
-        KDDW_CO_AWAIT Platform::instance() -> tests_waitForResize(group2->view());
+        KDDW_CO_AWAIT Platform::instance()->tests_waitForResize(group2->view());
 
         // Check that group2 moved up to y=0
         CHECK_EQ(group2->view()->y(), 0);
 
         // Close 2
         dock2->close();
-        KDDW_CO_AWAIT Platform::instance() -> tests_waitForResize(dock3->view());
+        KDDW_CO_AWAIT Platform::instance()->tests_waitForResize(dock3->view());
 
         CHECK(layout->checkSanity());
         CHECK_EQ(layout->count(), 3);
@@ -99,7 +99,7 @@ KDDW_QCORO_TASK tst_invalidPlaceholderPosition()
 
         toRestore2->open();
 
-        KDDW_CO_AWAIT Platform::instance() -> tests_waitForResize(group3->view());
+        KDDW_CO_AWAIT Platform::instance()->tests_waitForResize(group3->view());
         CHECK(layout->checkSanity());
         CHECK_EQ(layout->count(), 3);
         CHECK_EQ(layout->placeholderCount(), 0);
@@ -167,7 +167,7 @@ KDDW_QCORO_TASK tst_startHidden2()
         CHECK_EQ(layout->count(), 2);
         CHECK_EQ(layout->placeholderCount(), 0);
 
-        KDDW_CO_AWAIT Platform::instance() -> tests_waitForResize(dock2->view());
+        KDDW_CO_AWAIT Platform::instance()->tests_waitForResize(dock2->view());
     }
 
     {
@@ -193,7 +193,7 @@ KDDW_QCORO_TASK tst_startHidden2()
 
         dock2->open();
         dock3->open();
-        KDDW_CO_AWAIT Platform::instance() -> tests_waitForResize(dock2->view());
+        KDDW_CO_AWAIT Platform::instance()->tests_waitForResize(dock2->view());
         layout->checkSanity();
     }
 
@@ -238,7 +238,7 @@ KDDW_QCORO_TASK tst_invalidJSON()
 KDDW_QCORO_TASK tst_keepLast()
 {
     // 1 event loop for DelayedDelete. Avoids LSAN warnings.
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(1);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(1);
     KDDW_TEST_RETURN(true);
 }
 

--- a/tests/tst_docks_slow2.cpp
+++ b/tests/tst_docks_slow2.cpp
@@ -53,7 +53,7 @@ KDDW_QCORO_TASK tst_invalidLayoutAfterRestore()
     m->addDockWidget(dock2, Location_OnRight);
     m->addDockWidget(dock3, Location_OnRight);
 
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForResize(layout);
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForResize(layout);
     const int oldContentsWidth = layout->layoutWidth();
     auto f1 = dock1->dptr()->group();
     dock3->close();
@@ -66,8 +66,8 @@ KDDW_QCORO_TASK tst_invalidLayoutAfterRestore()
     CHECK(dock3->titleBar()->isVisible());
     dock2->open();
     dock1->open();
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForEvent(m.get(), Event::LayoutRequest); // So MainWindow min
-                                                                                             // size is updated
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForEvent(m.get(), Event::LayoutRequest); // So MainWindow min
+                                                                                           // size is updated
 
     Item *item1 = layout->itemForGroup(dock1->dptr()->group());
     Item *item3 = layout->itemForGroup(dock3->dptr()->group());
@@ -84,7 +84,7 @@ KDDW_QCORO_TASK tst_invalidLayoutAfterRestore()
     f2->detachTab(dock2);
     CHECK(!f2.data());
 
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(200);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(200);
     auto fw2 = dock2->floatingWindow();
     CHECK_EQ(layout->view()->minSize().width(),
              2 * Item::layoutSpacing + item1->minSize().width() + item3->minSize().width()
@@ -143,9 +143,9 @@ KDDW_QCORO_TASK tst_setFloatingWhenSideBySide()
         CHECK(item2);
         dock2->close();
         dock3->close();
-        KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(f2);
+        KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(f2);
         dock2->open();
-        KDDW_CO_AWAIT Platform::instance() -> tests_waitForResize(dock2->view());
+        KDDW_CO_AWAIT Platform::instance()->tests_waitForResize(dock2->view());
 
         CHECK_EQ(item2->geometry(), dock2->dptr()->group()->view()->geometry());
         layout->checkSanity();
@@ -171,7 +171,7 @@ KDDW_QCORO_TASK tst_dockWindowWithTwoSideBySideFramesIntoCenter()
     fw2->view()->move(fw->x() + fw->width() + 100, fw->y());
 
     // QtQuick is a bit more async than QWidgets. Wait for the move.
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForEvent(fw2->view()->window(), Event::Move);
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForEvent(fw2->view()->window(), Event::Move);
 
     auto da2 = fw2->dropArea();
     const Point dragDestPos = da2->mapToGlobal(da2->rect().center());
@@ -181,7 +181,7 @@ KDDW_QCORO_TASK tst_dockWindowWithTwoSideBySideFramesIntoCenter()
     auto f2 = fw2->groups().constFirst();
 
     // run one event loop, needed by flutter
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(1);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(1);
 
     CHECK_EQ(f2->dockWidgetCount(), 3);
 
@@ -203,13 +203,13 @@ KDDW_QCORO_TASK tst_dockWindowWithTwoSideBySideFramesIntoRight()
     fw2->view()->move(fw->x() + fw->width() + 100, fw->y());
 
 
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(1000);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(1000);
 
     KDDW_CO_AWAIT dragFloatingWindowTo(fw, fw2->dropArea(), DropLocation_Right); // Outer right instead of Left
 
 
     // run one event loop, needed by flutter
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(1000);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(1000);
 
     CHECK_EQ(fw2->groups().size(), 3);
     CHECK(fw2->dropArea()->checkSanity());
@@ -222,7 +222,7 @@ KDDW_QCORO_TASK tst_dockWindowWithTwoSideBySideFramesIntoLeft()
     EnsureTopLevelsDeleted e;
 
     auto fw = createFloatingWindow();
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(1000);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(1000);
     fw->view()->move(200, 200);
     fw->setObjectName("fw1");
 
@@ -235,12 +235,12 @@ KDDW_QCORO_TASK tst_dockWindowWithTwoSideBySideFramesIntoLeft()
     fw2->view()->move(fw->x() + fw->width() + 100, fw->y());
 
     CHECK(fw2->dropArea()->checkSanity());
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(1000);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(1000);
 
     KDDW_CO_AWAIT dragFloatingWindowTo(fw, fw2->dropArea(), DropLocation_Left);
 
     // run one event loop, needed by flutter
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(1000);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(1000);
 
     CHECK_EQ(fw2->groups().size(), 3);
     CHECK(fw2->dropArea()->checkSanity());
@@ -251,7 +251,7 @@ KDDW_QCORO_TASK tst_dockWindowWithTwoSideBySideFramesIntoLeft()
 KDDW_QCORO_TASK tst_keepLast()
 {
     // 1 event loop for DelayedDelete. Avoids LSAN warnings.
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(1);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(1);
     KDDW_TEST_RETURN(true);
 }
 

--- a/tests/tst_docks_slow3.cpp
+++ b/tests/tst_docks_slow3.cpp
@@ -60,7 +60,7 @@ KDDW_QCORO_TASK tst_dockWidgetGetsFocusWhenDocked()
     dw2->setGuestView(le2->asWrapper());
     dw1->open();
     dw2->open();
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(200);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(200);
 
     auto fw1 = dw1->floatingWindow();
     ObjectGuard<Core::FloatingWindow> fw2 = dw2->floatingWindow();
@@ -76,12 +76,12 @@ KDDW_QCORO_TASK tst_dockWidgetGetsFocusWhenDocked()
 
     le1->setFocus(Qt::MouseFocusReason);
 
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(200);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(200);
     CHECK(dw1->isFocused());
 
     CHECK(fw1->view()->isActiveWindow());
     KDDW_CO_AWAIT dragFloatingWindowTo(fw2, fw1->dropArea(), DropLocation_Left);
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForEvent(fw1, Event::WindowActivate);
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForEvent(fw1, Event::WindowActivate);
 
     /// We dropped into floating window 1, it should still be active
     CHECK(fw1->view()->isActiveWindow());
@@ -214,14 +214,14 @@ KDDW_QCORO_TASK tst_close()
              centralDock->dptr()->group()->view()->geometry().right() + Item::layoutSpacing
                  + 1);
     leftDock->close();
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(250);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(250);
     CHECK_EQ(centralDock->dptr()->group()->view()->x(), 0);
     CHECK_EQ(rightDock->dptr()->group()->view()->x(),
              centralDock->dptr()->group()->view()->geometry().right() + Item::layoutSpacing
                  + 1);
 
     rightDock->close();
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(250);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(250);
     Margins margins = mainwindow->centerWidgetMargins();
     CHECK_EQ(centralDock->dptr()->group()->view()->width(),
              mainwindow->width() - 0 * 2 - margins.left() - margins.right());
@@ -295,10 +295,10 @@ KDDW_QCORO_TASK tst_positionWhenShown()
     auto window = createMainWindow();
     auto dock1 = newDockWidget("1");
     dock1->open();
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(1000); // Wait for group to settle
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(1000); // Wait for group to settle
     const Point desiredPos = Point(100, 100);
     dock1->view()->window()->setFramePosition(desiredPos);
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(1000); // Wait for group to settle
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(1000); // Wait for group to settle
     CHECK_EQ(dock1->view()->window()->framePosition(), desiredPos);
 
     dock1->close();
@@ -316,7 +316,7 @@ KDDW_QCORO_TASK tst_positionWhenShown()
 KDDW_QCORO_TASK tst_keepLast()
 {
     // 1 event loop for DelayedDelete. Avoids LSAN warnings.
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(1);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(1);
     KDDW_TEST_RETURN(true);
 }
 

--- a/tests/tst_docks_slow4.cpp
+++ b/tests/tst_docks_slow4.cpp
@@ -104,7 +104,7 @@ KDDW_QCORO_TASK tst_dock2FloatingWidgetsTabbed()
 
     // 2.6 Drag the tabbed group over a 3rd floating window
     auto dock3 = createDockWidget("doc3");
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(1000); // Test is flaky otherwise
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(1000); // Test is flaky otherwise
 
     auto fw2 = dock2->floatingWindow();
     finalPoint = dock3->window()->geometry().center() + Point(7, 7);
@@ -161,7 +161,7 @@ KDDW_QCORO_TASK tst_restoreSimple()
     const Point dock2FloatingPoint = Point(150, 150);
     dock2->view()->window()->setFramePosition(dock2FloatingPoint);
     CHECK(dock2->isVisible());
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(1000); // Wait for group to settle
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(1000); // Wait for group to settle
 
     const Point dock3FloatingPoint = Point(200, 200);
     dock3->view()->window()->setFramePosition(dock3FloatingPoint);
@@ -211,7 +211,7 @@ KDDW_QCORO_TASK tst_restoreSimple()
     dock3->dptr()->morphIntoFloatingWindow(); // as it would take 1 event loop. Do it now so we can
                                               // compare already.
 
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(300);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(300);
     CHECK_EQ(dock3->view()->window()->framePosition(), dock3FloatingPoint);
 
     KDDW_CO_RETURN(true);
@@ -229,7 +229,7 @@ KDDW_QCORO_TASK tst_restoreSimplest()
     LayoutSaver saver;
     CHECK(saver.saveToFile(QStringLiteral("layout_tst_restoreSimplest.json")));
 
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(300);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(300);
 
     CHECK(layout->checkSanity());
     CHECK(saver.restoreFromFile(QStringLiteral("layout_tst_restoreSimplest.json")));
@@ -241,7 +241,7 @@ KDDW_QCORO_TASK tst_restoreSimplest()
 KDDW_QCORO_TASK tst_keepLast()
 {
     // 1 event loop for DelayedDelete. Avoids LSAN warnings.
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(1);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(1);
     KDDW_TEST_RETURN(true);
 }
 

--- a/tests/tst_docks_slow5.cpp
+++ b/tests/tst_docks_slow5.cpp
@@ -73,7 +73,7 @@ KDDW_QCORO_TASK tst_28NestedWidgets()
         for (int i : docksToHide) {
             docksToCreate.at(i).createdDock->close();
             layout->checkSanity();
-            KDDW_CO_AWAIT Platform::instance() -> tests_wait(200);
+            KDDW_CO_AWAIT Platform::instance()->tests_wait(200);
         }
 
         layout->checkSanity();
@@ -90,8 +90,8 @@ KDDW_QCORO_TASK tst_28NestedWidgets()
         for (auto dock : docksToCreate) {
             if (dock.createdDock && dock.createdDock->isVisible()) {
                 dock.createdDock->close();
-                KDDW_CO_AWAIT Platform::instance() -> tests_wait(200); // Wait for the docks to be closed. TODO Replace with a global event
-                                                                       // filter and wait for any resize ?
+                KDDW_CO_AWAIT Platform::instance()->tests_wait(200); // Wait for the docks to be closed. TODO Replace with a global event
+                                                                     // filter and wait for any resize ?
             }
             ++i;
         }
@@ -354,7 +354,8 @@ KDDW_QCORO_TASK tst_28NestedWidgets()
     KDDW_TEST_RETURN(true);
 }
 
-static const auto s_tests = std::vector<KDDWTest> {
+static const auto s_tests = std::vector<KDDWTest>
+{
 #if !defined(KDDW_FRONTEND_FLUTTER)
     TEST(tst_28NestedWidgets)
 #endif

--- a/tests/tst_docks_slow6.cpp
+++ b/tests/tst_docks_slow6.cpp
@@ -49,15 +49,15 @@ KDDW_QCORO_TASK tst_isFocused()
         auto dock2 = createDockWidget(QStringLiteral("dock2"),
                                       Platform::instance()->tests_createFocusableView({ true }));
 
-        KDDW_CO_AWAIT Platform::instance() -> tests_wait(400); // macOS is flaky here, needs dock2 to be shown first before focusing dock1,
-                                                               // otherwise dock1 looses again
+        KDDW_CO_AWAIT Platform::instance()->tests_wait(400); // macOS is flaky here, needs dock2 to be shown first before focusing dock1,
+                                                             // otherwise dock1 looses again
 
         dock1->window()->move(400, 200);
 
         // 2. Raise dock1 and focus its line edit
         dock1->raise();
         dock1->guestView()->setFocus(Qt::OtherFocusReason);
-        KDDW_CO_AWAIT Platform::instance() -> tests_waitForEvent(dock1->guestView().get(), Event::FocusIn);
+        KDDW_CO_AWAIT Platform::instance()->tests_waitForEvent(dock1->guestView().get(), Event::FocusIn);
 
         CHECK(dock1->isFocused());
         CHECK(!dock2->isFocused());
@@ -65,10 +65,10 @@ KDDW_QCORO_TASK tst_isFocused()
         // 3. Raise dock2 and focus its line edit
         dock2->view()->raiseAndActivate();
         if (!dock2->window()->window()->isActive())
-            KDDW_CO_AWAIT Platform::instance() -> tests_waitForEvent(dock2->view()->window(), Event::WindowActivate);
+            KDDW_CO_AWAIT Platform::instance()->tests_waitForEvent(dock2->view()->window(), Event::WindowActivate);
 
         dock2->guestView()->setFocus(Qt::OtherFocusReason);
-        KDDW_CO_AWAIT Platform::instance() -> tests_waitForEvent(dock1->guestView().get(), Event::FocusIn);
+        KDDW_CO_AWAIT Platform::instance()->tests_waitForEvent(dock1->guestView().get(), Event::FocusIn);
 
         CHECK(!dock1->isFocused());
         CHECK(dock2->guestView()->hasFocus());
@@ -91,7 +91,7 @@ KDDW_QCORO_TASK tst_isFocused()
         auto oldFw3 = dock3->window();
         dock3->raise();
         dock3->guestView()->setFocus(Qt::OtherFocusReason);
-        KDDW_CO_AWAIT Platform::instance() -> tests_waitForEvent(dock1->guestView().get(), Event::FocusIn);
+        KDDW_CO_AWAIT Platform::instance()->tests_waitForEvent(dock1->guestView().get(), Event::FocusIn);
         CHECK(!dock1->isFocused());
         CHECK(!dock2->isFocused());
         CHECK(dock3->isFocused());
@@ -100,19 +100,20 @@ KDDW_QCORO_TASK tst_isFocused()
         dock2->addDockWidgetToContainingWindow(dock3, Location_OnLeft);
         dock2->raise();
         dock2->guestView()->setFocus(Qt::OtherFocusReason);
-        KDDW_CO_AWAIT Platform::instance() -> tests_waitForEvent(dock2->guestView().get(), Event::FocusIn);
+        KDDW_CO_AWAIT Platform::instance()->tests_waitForEvent(dock2->guestView().get(), Event::FocusIn);
         CHECK(!dock1->isFocused());
         CHECK(dock2->isFocused());
         CHECK(!dock3->isFocused());
     }
 
     // Spin one event loop so we so some deleteLater()s run. Makes LSAN happy.
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(1000);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(1000);
 
     KDDW_CO_RETURN(true);
 }
 
-static const auto s_tests = std::vector<KDDWTest> {
+static const auto s_tests = std::vector<KDDWTest>
+{
 #if !defined(KDDW_FRONTEND_FLUTTER)
     TEST(tst_isFocused)
 #endif

--- a/tests/tst_docks_slow7.cpp
+++ b/tests/tst_docks_slow7.cpp
@@ -126,13 +126,13 @@ KDDW_QCORO_TASK tst_negativeAnchorPosition()
 
     d2->close();
 
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForResize(d3->view());
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForResize(d3->view());
     d2->open(); // Should not result in negative anchor positions (Test will fail due to a spdlog warning)
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForResize(d3->view());
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForResize(d3->view());
     layout->checkSanity();
 
     d2->close();
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForResize(d3->view());
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForResize(d3->view());
     layout->checkSanity();
 
     // Now resize the Window, after removing middle one
@@ -145,7 +145,7 @@ KDDW_QCORO_TASK tst_negativeAnchorPosition()
     layout->setLayoutSize(newSize);
 
     d2->destroyLater();
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(d2);
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(d2);
     layout->checkSanity();
 
     KDDW_TEST_RETURN(true);
@@ -236,7 +236,7 @@ KDDW_QCORO_TASK tst_negativeAnchorPosition4()
     layout->checkSanity();
     docks.at(0).createdDock->destroyLater();
     docks.at(4).createdDock->destroyLater();
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForDeleted(docks.at(4).createdDock);
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForDeleted(docks.at(4).createdDock);
 
     KDDW_TEST_RETURN(true);
 }
@@ -400,7 +400,7 @@ KDDW_QCORO_TASK tst_crash2()
                 layout->checkSanity();
                 if (i == 2) {
                     // Wait for the resizes. This used to make the app crash.
-                    KDDW_CO_AWAIT Platform::instance() -> tests_wait(1000);
+                    KDDW_CO_AWAIT Platform::instance()->tests_wait(1000);
                 }
 
                 docks[i]->setFloating(floatings[i]);
@@ -428,7 +428,7 @@ KDDW_QCORO_TASK tst_crash2()
 KDDW_QCORO_TASK tst_keepLast()
 {
     // 1 event loop for DelayedDelete. Avoids LSAN warnings.
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(1);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(1);
     KDDW_TEST_RETURN(true);
 }
 

--- a/tests/tst_docks_slow8.cpp
+++ b/tests/tst_docks_slow8.cpp
@@ -115,7 +115,7 @@ void TestDocks::tst_resizeWindow()
     }
 
     m->view()->showMaximized();
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForResize(m->view());
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForResize(m->view());
 
     const int maximizedWidth1 = dock1->width();
     const int maximizedWidth2 = dock2->width();
@@ -126,7 +126,7 @@ void TestDocks::tst_resizeWindow()
     QVERIFY(relativeDifference <= 0.01);
 
     m->view()->showNormal();
-    KDDW_CO_AWAIT Platform::instance() -> tests_waitForResize(m->view());
+    KDDW_CO_AWAIT Platform::instance()->tests_waitForResize(m->view());
 
     const int newWidth1 = dock1->width();
     const int newWidth2 = dock2->width();
@@ -343,7 +343,7 @@ void TestDocks::tst_tabBarWithHiddenTitleBar()
     }
 
     // 1 event loop for DelayedDelete. Avoids LSAN warnings.
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(1);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(1);
 }
 
 int main(int argc, char *argv[])

--- a/tests/tst_view.cpp
+++ b/tests/tst_view.cpp
@@ -146,7 +146,7 @@ KDDW_QCORO_TASK tst_viewGeometry()
     const Rect newChildGeo(1, 2, 300, 301);
     childView->setGeometry(newChildGeo);
 
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(500);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(500);
 
     CHECK(!childView->isRootView());
     CHECK_EQ(childView->size(), newChildGeo.size());
@@ -231,11 +231,11 @@ KDDW_QCORO_TASK tst_hasFocus()
     rootView->activateWindow();
 
     CHECK(rootView->controller()->isVisible());
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(0);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(0);
     CHECK(!rootView->hasFocus());
 
     rootView->setFocus(Qt::MouseFocusReason);
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(200); // QWidget::setFocus() requires 1 event loop iteration
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(200); // QWidget::setFocus() requires 1 event loop iteration
     CHECK(rootView->hasFocus());
     CHECK(rootView->equals(Platform::instance()->focusedView()));
 
@@ -244,7 +244,7 @@ KDDW_QCORO_TASK tst_hasFocus()
     CHECK(rootView->equals(Platform::instance()->focusedView()));
     child1->controller()->setVisible(true);
     child1->setFocus(Qt::MouseFocusReason);
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(200); // QWidget::setFocus() requires 1 event loop iteration
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(200); // QWidget::setFocus() requires 1 event loop iteration
     CHECK(child1->hasFocus());
     CHECK(child1->equals(Platform::instance()->focusedView()));
 
@@ -259,7 +259,7 @@ KDDW_QCORO_TASK tst_parentDeletesChildViews()
     rootView->show();
     rootView->activateWindow();
     CHECK(rootView->controller()->isVisible());
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(0);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(0);
     auto child = createViewAndWindow({}, rootView);
     child->show();
     CHECK(child->isVisible());

--- a/tests/tst_window.cpp
+++ b/tests/tst_window.cpp
@@ -63,7 +63,7 @@ KDDW_QCORO_TASK tst_resize()
     const KDDockWidgets::Size newSize(501, 502);
     window->resize(newSize.width(), newSize.height());
 
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(100);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(100);
 
     CHECK_EQ(window->size(), newSize);
 
@@ -106,7 +106,7 @@ KDDW_QCORO_TASK tst_geometry()
     const auto geo = KDDockWidgets::Rect(100, 100, 1000, 1000);
     window->setGeometry(geo);
 
-    KDDW_CO_AWAIT Platform::instance() -> tests_wait(100);
+    KDDW_CO_AWAIT Platform::instance()->tests_wait(100);
     CHECK_EQ(window->geometry(), geo);
 
     window->destroy();

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -161,7 +161,7 @@ void KDDockWidgets::Tests::pressOn(Point globalPos, Window::Ptr receiver)
 
 KDDW_QCORO_TASK KDDockWidgets::Tests::releaseOn(Point globalPos, View *receiver)
 {
-    KDDW_CO_AWAIT Platform::instance() -> tests_releaseOn(globalPos, receiver);
+    KDDW_CO_AWAIT Platform::instance()->tests_releaseOn(globalPos, receiver);
     KDDW_CO_RETURN true;
 }
 

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -188,7 +188,7 @@ inline KDDW_QCORO_TASK drag(Core::View *sourceWidget, Point pressGlobalPos, Poin
 {
     if (buttonActions & ButtonAction_Press) {
         if (s_pauseBeforePress)
-            KDDW_CO_AWAIT Core::Platform::instance() -> tests_wait(DEBUGGING_PAUSE_DURATION);
+            KDDW_CO_AWAIT Core::Platform::instance()->tests_wait(DEBUGGING_PAUSE_DURATION);
 
         pressOn(pressGlobalPos, sourceWidget);
     }
@@ -196,7 +196,7 @@ inline KDDW_QCORO_TASK drag(Core::View *sourceWidget, Point pressGlobalPos, Poin
     sourceWidget->activateWindow();
 
     if (s_pauseBeforeMove)
-        KDDW_CO_AWAIT Core::Platform::instance() -> tests_wait(DEBUGGING_PAUSE_DURATION);
+        KDDW_CO_AWAIT Core::Platform::instance()->tests_wait(DEBUGGING_PAUSE_DURATION);
 
     KDDW_CO_AWAIT moveMouseTo(globalDest, sourceWidget);
     pressGlobalPos = sourceWidget->mapToGlobal(Point(10, 10));
@@ -236,7 +236,7 @@ inline KDDW_QCORO_TASK dragFloatingWindowTo(Core::FloatingWindow *fw, Core::Drop
                                             DropLocation dropLocation)
 {
     // run one event loop, needed by flutter
-    KDDW_CO_AWAIT Core::Platform::instance() -> tests_wait(100);
+    KDDW_CO_AWAIT Core::Platform::instance()->tests_wait(100);
 
     auto draggable = draggableFor(fw->view());
     assert(draggable);


### PR DESCRIPTION
clang-format v18 is adding whitespace where we don't want it,
eg:

```
-    KDDW_CO_AWAIT Platform::instance()->tests_wait(500);
+    KDDW_CO_AWAIT Platform::instance() -> tests_wait(500);
```

maybe we can control this with a setting in .clang-format
