### PR TITLE
Revert "KDPySide2ModuleBuild.cmake - sync to upstream"

### DIFF
--- a/cmake/KDAB/modules/KDPySide2ModuleBuild.cmake
+++ b/cmake/KDAB/modules/KDPySide2ModuleBuild.cmake
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Renato Araujo Oliveira Filho <renato.araujo@kdab.com>
 #
 # SPDX-License-Identifier: BSD-3-Clause
@@ -129,6 +129,7 @@ macro(
             $<TARGET_PROPERTY:Shiboken2::shiboken,LOCATION> ${GENERATOR_EXTRA_FLAGS} ${globalInclude}
             --include-paths=${shiboken_include_dirs} --typesystem-paths=${shiboken_typesystem_dirs}
             ${shiboken_framework_include_dirs_option} --output-directory=${CMAKE_CURRENT_BINARY_DIR} ${typesystemXML}
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/python/fixup.py ${outputSource}
         DEPENDS ${typesystemXML} ${dependsArg}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         COMMENT "Running generator for ${libraryName} binding..."


### PR DESCRIPTION
This reverts commit 92a485f74eecd387524e9e3614274593a4623fa4.

breaks the compile for pyside2 bindings.
requires more investigation
