### PR TITLE
Set default iconSize for Button's paintEvent

### DIFF
--- a/src/private/widgets/TitleBarWidget.cpp
+++ b/src/private/widgets/TitleBarWidget.cpp
@@ -49,6 +49,7 @@ void Button::paintEvent(QPaintEvent *)
     opt.subControls = QStyle::SC_None;
     opt.features = QStyleOptionToolButton::None;
     opt.icon = icon();
+    opt.iconSize = iconSize();
 
     // The first icon size is for scaling 1x, and is what QStyle expects. QStyle will pick ones
     // with higher resolution automatically when needed.


### PR DESCRIPTION
Without this, SVGs won't get rendered since QIcon::availableSizes() returns an empty list for them.