### PR TITLE
Don't destroy DockWidget if it's shown immediately after being closed

### DIFF
--- a/src/private/Frame.cpp
+++ b/src/private/Frame.cpp
@@ -749,6 +749,7 @@ void Frame::scheduleDeleteLater()
 {
     qCDebug(creation) << Q_FUNC_INFO << this;
     m_beingDeleted = true;
+    Q_EMIT beingDeleted();
     QTimer::singleShot(0, this, [this] {
         // Can't use deleteLater() here due to QTBUG-83030 (deleteLater() never delivered if triggered by a sendEvent() before event loop starts)
         delete this;

--- a/src/private/Frame_p.h
+++ b/src/private/Frame_p.h
@@ -325,6 +325,7 @@ Q_SIGNALS:
     void focusedWidgetChanged();
     void isMDIChanged();
     void actualTitleBarChanged();
+    void beingDeleted();
 
 protected:
     void isFocusedChangedCallback() final;

--- a/src/private/LayoutWidget.cpp
+++ b/src/private/LayoutWidget.cpp
@@ -126,7 +126,7 @@ void LayoutWidget::restorePlaceholder(DockWidgetBase *dw, Layouting::Item *item,
     }
 
     auto frame = qobject_cast<Frame *>(item->guestAsQObject());
-    Q_ASSERT(frame);
+    Q_ASSERT(frame && !frame->beingDeletedLater());
 
     if (tabIndex != -1 && frame->dockWidgetCount() >= tabIndex) {
         frame->insertWidget(dw, tabIndex);


### PR DESCRIPTION
When a DockWidget is closed, Frame::scheduleDeleteLater gets called, which doesn't immediately delete the Frame. If the DockWidget is shown again before ~Frame has had a chance to run, the DockWidget will become a parent of the Frame again and will be destroyed when Frame gets deleted.

Fix this by doing the necessary housekeeping when the Frame is scheduled for deletion.