### PR TITLE
Fix rename of Wayland test

### DIFF
--- a/tests/wayland/CMakeLists.txt
+++ b/tests/wayland/CMakeLists.txt
@@ -47,4 +47,4 @@ function(add_wayland_test test srcs)
     )
 endfunction()
 
-add_wayland_test(tst_wayland_qtwidgets tst_qtwidgets.cpp)
+add_wayland_test(tst_wayland_qtwidgets tst_wayland.cpp)


### PR DESCRIPTION
Commit f76009d1 renamed `tests/wayland/tst_qtwidgets.cpp` to `tst_wayland.cpp`, but missed updating the name in `CMakeLists.txt`.