### PR TITLE
Fix compilation wrt min/max macros

### DIFF
--- a/src/3rdparty/kdtoolbox/KDStlContainerAdaptor.h
+++ b/src/3rdparty/kdtoolbox/KDStlContainerAdaptor.h
@@ -296,7 +296,7 @@ struct StdVectorAdaptor : std::vector<T, Args...>
     {
         const auto s = size();
         if (from < 0)
-            from = std::max(from + s, 0);
+            from = (std::max)(from + s, 0);
         if (from < s) {
             const auto b = this->begin();
             const auto e = this->end();
@@ -356,7 +356,7 @@ struct StdVectorAdaptor : std::vector<T, Args...>
 
         if (len < 0)
             len = s;
-        len = std::min(len, s - pos);
+        len = (std::min)(len, s - pos);
 
         const auto b = this->begin() + pos;
         const auto e = b + len;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -460,7 +460,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR IS_CLANG_BUILD)
     endif()
 endif()
 
-if(MSVC)
+if(WIN32)
     # To unbreak std::min/max
     target_compile_definitions(kddockwidgets PRIVATE NOMINMAX)
 endif()

--- a/src/KDDockWidgets.h
+++ b/src/KDDockWidgets.h
@@ -425,7 +425,7 @@ inline T *findAncestor(QWidget *widget)
 template<typename T>
 T bound(T minVal, T value, T maxVal)
 {
-    return std::max(minVal, std::min(value, maxVal));
+    return (std::max)(minVal, (std::min)(value, maxVal));
 }
 
 inline bool fuzzyCompare(double a, double b, double epsilon = 0.0001)

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -289,7 +289,7 @@ Rect MainWindow::Private::rectForOverlay(Core::Group *group, SideBarLocation loc
             (leftSideBar && leftSideBar->isVisible()) ? leftSideBar->width() : 0;
         const int rightSideBarWidth =
             (rightSideBar && rightSideBar->isVisible()) ? rightSideBar->width() : 0;
-        rect.setHeight(std::max(300, group->view()->minSize().height()));
+        rect.setHeight((std::max)(300, group->view()->minSize().height()));
         rect.setWidth(centralAreaGeo.width() - margin * 2 - leftSideBarWidth - rightSideBarWidth);
         rect.moveLeft(margin + leftSideBarWidth);
         if (location == SideBarLocation::South) {
@@ -308,7 +308,7 @@ Rect MainWindow::Private::rectForOverlay(Core::Group *group, SideBarLocation loc
             (topSideBar && topSideBar->isVisible()) ? topSideBar->height() : 0;
         const int bottomSideBarHeight =
             (bottomSideBar && bottomSideBar->isVisible()) ? bottomSideBar->height() : 0;
-        rect.setWidth(std::max(300, group->view()->minSize().width()));
+        rect.setWidth((std::max)(300, group->view()->minSize().width()));
         rect.setHeight(centralAreaGeo.height() - topSideBarHeight - bottomSideBarHeight
                        - centerWidgetMargins.top() - centerWidgetMargins.bottom());
         rect.moveTop(sb->view()->mapTo(q->view(), Point(0, 0)).y() + topSideBarHeight - 1);
@@ -382,7 +382,7 @@ SideBarLocation MainWindow::Private::preferredSideBar(Core::DockWidget *dw) cons
     }
 
     const Core::LayoutBorderLocations borders = item->adjacentLayoutBorders();
-    const double aspectRatio = group->width() / (std::max(1, group->height()) * 1.0);
+    const double aspectRatio = group->width() / ((std::max)(1, group->height()) * 1.0);
 
     /// 1. It's touching all borders
     if (borders == Core::LayoutBorderLocation_All) {
@@ -462,26 +462,26 @@ void MainWindow::Private::updateOverlayGeometry(Size suggestedSize)
         switch (sb->location()) {
         case SideBarLocation::North: {
             const int maxHeight = q->height() - group->pos().y() - 10; // gap
-            newGeometry.setHeight(std::min(suggestedSize.height(), maxHeight));
+            newGeometry.setHeight((std::min)(suggestedSize.height(), maxHeight));
             break;
         }
         case SideBarLocation::South: {
             const int maxHeight = sb->pos().y() - m_layout->view()->pos().y() - 10; // gap
             const int bottom = newGeometry.bottom();
-            newGeometry.setHeight(std::min(suggestedSize.height(), maxHeight));
+            newGeometry.setHeight((std::min)(suggestedSize.height(), maxHeight));
             newGeometry.moveBottom(bottom);
             break;
         }
         case SideBarLocation::East: {
             const int maxWidth = sb->pos().x() - m_layout->view()->pos().x() - 10; // gap
             const int right = newGeometry.right();
-            newGeometry.setWidth(std::min(suggestedSize.width(), maxWidth));
+            newGeometry.setWidth((std::min)(suggestedSize.width(), maxWidth));
             newGeometry.moveRight(right);
             break;
         }
         case SideBarLocation::West: {
             const int maxWidth = q->width() - group->pos().x() - 10; // gap
-            newGeometry.setWidth(std::min(suggestedSize.width(), maxWidth));
+            newGeometry.setWidth((std::min)(suggestedSize.width(), maxWidth));
             break;
         }
         case SideBarLocation::None:

--- a/src/qtcompat/geometry_helpers_p.h
+++ b/src/qtcompat/geometry_helpers_p.h
@@ -67,12 +67,12 @@ public:
 
     Size expandedTo(Size sz) const
     {
-        return { std::max(m_width, sz.m_width), std::max(m_height, sz.height()) };
+        return { (std::max)(m_width, sz.m_width), (std::max)(m_height, sz.height()) };
     }
 
     Size boundedTo(Size sz) const
     {
-        return { std::min(m_width, sz.m_width), std::min(m_height, sz.height()) };
+        return { (std::min)(m_width, sz.m_width), (std::min)(m_height, sz.height()) };
     }
 
     bool operator==(Size other) const
@@ -360,13 +360,13 @@ public:
 
     Rect intersected(Rect other) const
     {
-        const int maxLeft = std::max(x(), other.x());
-        const int minRight = std::min(right(), other.right());
+        const int maxLeft = (std::max)(x(), other.x());
+        const int minRight = (std::min)(right(), other.right());
         if (maxLeft > minRight)
             return Rect();
 
-        const int maxTop = std::max(y(), other.y());
-        const int minBottom = std::min(bottom(), other.bottom());
+        const int maxTop = (std::max)(y(), other.y());
+        const int minBottom = (std::min)(bottom(), other.bottom());
         if (maxTop > minBottom)
             return Rect();
 


### PR DESCRIPTION
- Add NOMINMAX not only on MSVC but on Windows, regardless of the compiler. Other compilers will likely still include minwindef.h (I learned this the hard way with clang on Windows today)
- Add parentheses around std::min/max in headers. So that users that don't define NOMINMAX don't have any problems.