### PR TITLE
Flutter qtgui

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,7 @@ option(KDDockWidgets_XLib "On Linux, link against XLib, for a more robust window
 option(KDDockWidgets_CODE_COVERAGE "Enable coverage reporting" OFF)
 option(KDDockWidgets_FLUTTER_NO_BINDINGS "Don't build flutter bindings, only the flutter frontend" OFF)
 option(KDDockWidgets_FLUTTER_TESTS_AOT "Flutter tests will be built in AOT mode" OFF)
+option(KDDockWidgets_FLUTTER_QWINDOW "Flutter backend will use QWindow and QtGui types" OFF)
 option(KDDockWidgets_NO_SPDLOG "Don't use spdlog, even if it is found." OFF)
 option(KDDockWidgets_USE_LLD "Use lld for linking" OFF)
 option(KDDockWidgets_USE_VALGRIND "Runs the tests under valgrind" OFF)
@@ -182,6 +183,9 @@ if(KDDockWidgets_FRONTENDS)
 
     if("flutter" IN_LIST KDDockWidgets_FRONTENDS)
         set(KDDW_FRONTEND_FLUTTER ON)
+        if(KDDockWidgets_FLUTTER_QWINDOW)
+            find_package(Qt6 6.6 NO_MODULE REQUIRED COMPONENTS Gui)
+        endif()
     endif()
 
     if("none" IN_LIST KDDockWidgets_FRONTENDS)
@@ -237,6 +241,10 @@ if(KDDW_FRONTEND_FLUTTER)
         message(FATAL_ERROR "The flutter frontend only supports developer-mode on Linux. "
                             "You can still develop on Windows/macOS but wait for test results from KDAB CI."
         )
+    endif()
+else()
+    if(KDDockWidgets_FLUTTER_QWINDOW)
+        message(FATAL_ERROR "KDDockWidgets_FLUTTER_QWINDOW only makes sense with the flutter backend")
     endif()
 endif()
 
@@ -345,10 +353,13 @@ endif()
 
 if(KDDW_FRONTEND_QT)
     set(CMAKE_CXX_STANDARD 17)
-    set(CMAKE_AUTOMOC ON)
-    set(CMAKE_AUTORCC ON)
 else()
     set(CMAKE_CXX_STANDARD 20)
+endif()
+
+if(KDDW_FRONTEND_QT OR KDDockWidgets_FLUTTER_QWINDOW)
+    set(CMAKE_AUTOMOC ON)
+    set(CMAKE_AUTORCC ON)
 endif()
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -168,6 +168,18 @@
             ]
         },
         {
+            "name": "release-flutter-qwindow",
+            "displayName": "release-flutter-qwindow",
+            "binaryDir": "${sourceDir}/build-release-flutter-qwindow",
+            "cacheVariables": {
+                "KDDockWidgets_FLUTTER_QWINDOW": "ON",
+                "KDDockWidgets_FLUTTER_NO_BINDINGS": "ON"
+            },
+            "inherits": [
+                "release-flutter"
+            ]
+        },
+        {
             "name": "dev-flutter-no-bindings",
             "displayName": "dev-flutter-no-bindings",
             "binaryDir": "${sourceDir}/build-dev-flutter-no-bindings",

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -220,7 +220,6 @@ set(KDDW_FRONTEND_DARTBINDINGS_SRCS
 set(KDDW_FRONTEND_QTCOMPAT_SRCS qtcompat/Object.cpp)
 
 set(KDDW_FRONTEND_FLUTTER_SRCS
-    ${KDDW_FRONTEND_QTCOMPAT_SRCS}
     flutter/Action.cpp
     flutter/ViewFactory.cpp
     flutter/Window.cpp
@@ -237,6 +236,10 @@ set(KDDW_FRONTEND_FLUTTER_SRCS
     flutter/views/MainWindow.cpp
     flutter/views/ClassicIndicatorsWindow.cpp
 )
+
+if(NOT KDDockWidgets_FLUTTER_QWINDOW)
+    set(KDDW_FRONTEND_FLUTTER_SRCS ${KDDW_FRONTEND_FLUTTER_SRCS} ${KDDW_FRONTEND_QTCOMPAT_SRCS})
+endif()
 
 if(KDDockWidgets_FLUTTER_NO_BINDINGS)
     # For a special build that just builds core/ and flutter/, but not generated/
@@ -376,6 +379,11 @@ if(KDDW_FRONTEND_FLUTTER)
     # So bindings are exported
     target_compile_definitions(kddockwidgets PRIVATE BUILDING_KDDockWidgets)
 
+    if(KDDockWidgets_FLUTTER_QWINDOW)
+        target_compile_definitions(kddockwidgets PUBLIC KDDW_FLUTTER_QWINDOW)
+        target_link_libraries(kddockwidgets PUBLIC Qt6::Gui Qt6::GuiPrivate)
+    endif()
+
     if(MSVC)
         set(FLUTTER_ENGINE_LIBRARY flutter_engine.dll.lib)
     else()
@@ -451,7 +459,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR IS_CLANG_BUILD)
     endif()
 
     # Disable -Wconversion for Qt6. The qsizetype to int conversions are harmless
-    if(NOT KDDockWidgets_QT6)
+    if(NOT KDDockWidgets_QT6 AND NOT KDDockWidgets_FLUTTER_QWINDOW)
         target_compile_options(kddockwidgets PRIVATE -Wconversion)
     endif()
 

--- a/src/KDDockWidgets.h
+++ b/src/KDDockWidgets.h
@@ -23,7 +23,7 @@
 
 #include "QtCompat_p.h"
 
-#ifdef KDDW_FRONTEND_QT
+#ifdef KDDW_QTGUI_TYPES
 #include "Qt5Qt6Compat_p.h"
 
 #ifdef Q_OS_WIN

--- a/src/QtCompat_p.h
+++ b/src/QtCompat_p.h
@@ -13,7 +13,12 @@
 
 // The goal of this file is to provide fallback types for non-Qt frontends such as Flutter
 
-#ifdef KDDW_FRONTEND_QT
+#if defined(KDDW_FRONTEND_QT) || defined(KDDW_FLUTTER_QWINDOW)
+// Qt uses QtGui, and Flutter optionally can
+#define KDDW_QTGUI_TYPES
+#endif
+
+#ifdef KDDW_QTGUI_TYPES
 
 #include <QCloseEvent>
 #include <QMouseEvent>
@@ -43,7 +48,7 @@
 
 namespace KDDockWidgets {
 
-#ifdef KDDW_FRONTEND_QT
+#ifdef KDDW_QTGUI_TYPES
 
 using Polygon = QPolygon;
 using Icon = QIcon;
@@ -294,7 +299,7 @@ public:
 #define KDDW_CO_RETURN return
 #endif
 
-#ifndef KDDW_FRONTEND_QT
+#ifndef KDDW_QTGUI_TYPES
 
 // Dummy Qt macros, to avoid too much ifdefs in core/
 #define Q_NAMESPACE

--- a/src/core/LayoutSaver_p.h
+++ b/src/core/LayoutSaver_p.h
@@ -268,9 +268,9 @@ public:
         s_currentLayoutBeingRestored = this;
 
         const auto screens = Core::Platform::instance()->screens();
-        const int numScreens = screens.size();
+        const auto numScreens = screens.size();
         screenInfo.reserve(numScreens);
-        for (int i = 0; i < numScreens; ++i) {
+        for (auto i = 0; i < numScreens; ++i) {
             ScreenInfo info;
             info.index = i;
             info.geometry = screens[i]->geometry();

--- a/src/core/ObjectGuard_p.h
+++ b/src/core/ObjectGuard_p.h
@@ -15,7 +15,7 @@
 /// i.e., it becomes null automatically once the object is destroyed
 /// For Qt, this is simply QPointer, for Flutter it's an equivalent.
 
-#if defined(KDDW_FRONTEND_QT)
+#if defined(KDDW_FRONTEND_QT) || defined(KDDW_FLUTTER_QWINDOW)
 
 #include <QPointer>
 

--- a/src/core/WidgetResizeHandler.cpp
+++ b/src/core/WidgetResizeHandler.cpp
@@ -16,6 +16,7 @@
 #include "View_p.h"
 #include "Logging_p.h"
 #include "DockRegistry_p.h"
+#include "QtCompat_p.h"
 
 #include "kddockwidgets/core/DockRegistry.h"
 #include "kddockwidgets/core/MDILayout.h"
@@ -27,12 +28,13 @@
 #include <cstdlib>
 
 #if defined(Q_OS_WIN)
+
 #if defined(KDDW_FRONTEND_QTWIDGETS)
 #include "../qtcommon/Platform.h"
 #include <QWidget>
 #endif
 
-#if defined(KDDW_FRONTEND_QT)
+#if defined(KDDW_QTGUI_TYPES)
 #include "../qtcommon/Window_p.h"
 #include <QGuiApplication>
 #include <QtGui/private/qhighdpiscaling_p.h>

--- a/src/core/nlohmann_helpers_p.h
+++ b/src/core/nlohmann_helpers_p.h
@@ -81,7 +81,7 @@ inline void to_json(nlohmann::json &j, const KDDockWidgets::Vector<QString> &str
         j.push_back(s);
     }
 }
-#ifdef KDDW_FRONTEND_QT
+#ifdef KDDW_QTGUI_TYPES
 
 inline void to_json(nlohmann::json &j, QSize size)
 {

--- a/src/core/spdlog_formatters_p.h
+++ b/src/core/spdlog_formatters_p.h
@@ -77,7 +77,7 @@ struct fmt::formatter<QString>
     }
 };
 
-#ifdef KDDW_FRONTEND_QT
+#ifdef KDDW_QTGUI_TYPES
 template<typename T>
 struct fmt::formatter<QVector<T>>
 {
@@ -215,7 +215,7 @@ struct fmt::formatter<KDDockWidgets::InitialOption>
     }
 };
 
-#ifndef KDDW_FRONTEND_QT
+#ifndef KDDW_QTGUI_TYPES
 template<typename T>
 struct fmt::formatter<KDDockWidgets::Vector<T>>
 {

--- a/src/flutter/views/View.cpp
+++ b/src/flutter/views/View.cpp
@@ -523,8 +523,7 @@ void View::raiseWindow(Core::View *)
 
 void View::onMouseEvent(Event::Type eventType, Point localPos, Point globalPos, bool leftIsPressed)
 {
-    Qt::MouseButtons buttons = Qt::NoButton;
-    buttons.setFlag(Qt::LeftButton, leftIsPressed);
+    Qt::MouseButton button = leftIsPressed ? Qt::LeftButton : Qt::NoButton;
     Qt::KeyboardModifiers modifiers = Qt::NoModifier;
 
     if (eventType == Event::MouseMove) {
@@ -532,7 +531,7 @@ void View::onMouseEvent(Event::Type eventType, Point localPos, Point globalPos, 
         flutter::Platform::s_lastCursorPosition = globalPos;
     }
 
-    auto me = new MouseEvent(eventType, localPos, globalPos, globalPos, buttons, buttons, modifiers);
+    auto me = new MouseEvent(eventType, localPos, globalPos, globalPos, button, button, modifiers);
 
     if (!deliverViewEventToFilters(me)) {
         // filters allowed the event to propagate, give it to the view.


### PR DESCRIPTION
feat: Allow flutter to build against QtGui types

will be useful for using it with a Qt embedder where it can
leverage our QWindow code
