### PR TITLE
fix: warnings in qtquick/dockwidgets example

### DIFF
--- a/examples/qtquick/dockwidgets/main.cpp
+++ b/examples/qtquick/dockwidgets/main.cpp
@@ -89,11 +89,11 @@ int main(int argc, char *argv[])
 #endif
 #endif
 
+    parser.process(app);
     auto flags = KDDockWidgets::Config::self().flags();
 
 #if defined(DOCKS_DEVELOPER_MODE)
     auto internalFlags = KDDockWidgets::Config::self().internalFlags();
-    parser.process(app);
 
     if (parser.isSet(noQtTool))
         internalFlags |= KDDockWidgets::Config::InternalFlag_DontUseQtToolWindowsForFloatingWindows;

--- a/examples/qtquick/dockwidgets/main.qml
+++ b/examples/qtquick/dockwidgets/main.qml
@@ -200,10 +200,10 @@ ApplicationWindow {
     }
 
     function toggleDockWidget(dw) {
-        if (dw.dockWidget.isOpen()) {
-            dw.dockWidget.close();
+        if (dw.isOpen) {
+            dw.close();
         } else {
-            dw.dockWidget.show();
+            dw.show();
         }
     }
 }


### PR DESCRIPTION
* Fix toggle button
* Actually call `parser.process()` regardless of DOCKS_DEVELOPER_MODE