### PR TITLE
fix restoring of nested main windows

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -9,6 +9,7 @@
   - Fix windows having transparency when drop indicators inhibited
   - Fix case where persistent central widget would detach when dragged
   - Allow to build against external KDBindings
+  - Fix restore layout of nested main windows (#508)
 
 * v2.1.0 (08 May 2024)
   - Added standalone layouting example using Slint

--- a/src/LayoutSaver.cpp
+++ b/src/LayoutSaver.cpp
@@ -528,7 +528,7 @@ bool LayoutSaver::restoreLayout(const QByteArray &data)
         if (!d->matchesAffinity(mainWindow->affinities()))
             continue;
 
-        if (!(d->m_restoreOptions & InternalRestoreOption::SkipMainWindowGeometry)) {
+        if (!(d->m_restoreOptions & InternalRestoreOption::SkipMainWindowGeometry) && !mainWindow->isInDockWidget()) {
             Window::Ptr window = mainWindow->view()->window();
             if (window->windowState() == WindowState::Maximized) {
                 // Restoring geometry needs to be done in normal state.

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -865,3 +865,15 @@ void MainWindow::setOverlayMargin(int margin)
     d->m_overlayMargin = margin;
     d->overlayMarginChanged.emit(margin);
 }
+
+bool MainWindow::isInDockWidget() const
+{
+    auto v = view();
+    if (!v)
+        return false;
+
+    if (auto p = v->parentView())
+        return p->is(ViewType::DockWidget);
+
+    return false;
+}

--- a/src/core/MainWindow.h
+++ b/src/core/MainWindow.h
@@ -232,6 +232,10 @@ public:
     /// @brief Returns the side bar at the specified location
     Core::SideBar *sideBar(SideBarLocation location) const;
 
+    /// Returns whether this main window is inside a dock widget
+    /// only ever true when using main windows nested inside main windows
+    bool isInDockWidget() const;
+
     // Internal public API:
 
     ///@internal

--- a/tests/qtwidgets/tst_qtwidgets.cpp
+++ b/tests/qtwidgets/tst_qtwidgets.cpp
@@ -2310,8 +2310,6 @@ void TestQtWidgets::tst_nestedMainWindowSaveRestore()
 
     LayoutSaver saver;
     QVERIFY(saver.restoreLayout(saver.serializeLayout()));
-
-    QEXPECT_FAIL("", "TODO: Fix nested widget visibility for #508", Continue);
     QVERIFY(mainWindow->isVisible());
 }
 


### PR DESCRIPTION
The code to deserialize the QWindow should only run for the top-level QMainWindow, not the nested ones.

Fixes issue #508