### PR TITLE
Fix Warning typesystem_kddockwidgets.xml

### DIFF
--- a/python/PyKDDockWidgets/kddockwidgets_global.h
+++ b/python/PyKDDockWidgets/kddockwidgets_global.h
@@ -33,3 +33,6 @@
 #include <kddockwidgets/qtwidgets/views/MainWindow.h>
 #include <kddockwidgets/qtwidgets/views/DockWidget.h>
 #include <kddockwidgets/qtcommon/View.h>
+# for cbor warnings and enum differ in qualifiers
+#include <QtCore/QCborStreamReader>
+#include <QtCore/qcborstreamreader.h>

--- a/python/PyKDDockWidgets/kddockwidgets_global.h
+++ b/python/PyKDDockWidgets/kddockwidgets_global.h
@@ -33,6 +33,6 @@
 #include <kddockwidgets/qtwidgets/views/MainWindow.h>
 #include <kddockwidgets/qtwidgets/views/DockWidget.h>
 #include <kddockwidgets/qtcommon/View.h>
-# for cbor warnings and enum differ in qualifiers
+#for cbor warnings and enum differ in qualifiers
 #include <QtCore/QCborStreamReader>
 #include <QtCore/qcborstreamreader.h>

--- a/python/PyKDDockWidgets/typesystem_kddockwidgets.xml
+++ b/python/PyKDDockWidgets/typesystem_kddockwidgets.xml
@@ -52,14 +52,14 @@
         <value-type name="InitialOption">
             <include file-name="kddockwidgets/KDDockWidgets.h" location="global"/>
         </value-type>
-        
+
         <object-type name="LayoutSaver">
             <include file-name="kddockwidgets/LayoutSaver.h" location="global"/>
         </object-type>
-        
+
         <object-type name="Config">
             <include file-name="kddockwidgets/Config.h" location="global"/>
-            
+
             <enum-type name="Flag" flags="Flags" />
             <enum-type name="CustomizableWidget" flags="CustomizableWidgets" />
             <enum-type name="InternalFlag" flags="InternalFlags" />
@@ -68,12 +68,12 @@
 
         <namespace-type name="Core" visible="no">
             <enum-type name="ViewType" />
-            
+
             <object-type name="DockWidgetViewInterface">
                 <include file-name="kddockwidgets/core/views/DockWidgetViewInterface.h" location="global"/>
                 <rejection class="KDDockWidgets::Core::DockWidgetViewInterface" field-name="m_dockWidget" />
             </object-type>
-            
+
             <object-type name="MainWindowViewInterface">
                 <include file-name="kddockwidgets/core/views/MainWindowViewInterface.h" location="global"/>
                 <rejection class="KDDockWidgets::Core::MainWindowViewInterface" field-name="m_mainWindow" />
@@ -85,11 +85,11 @@
             <object-type name="MainWindow">
                 <include file-name="kddockwidgets/qtwidgets/views/MainWindow.h" location="global"/>
             </object-type>
-            
+
             <object-type name="DockWidget">
                 <include file-name="kddockwidgets/qtwidgets/views/DockWidget.h" location="global"/>
             </object-type>
-            
+
         </namespace-type>
     </namespace-type>
 </typesystem>

--- a/python/PyKDDockWidgets/typesystem_kddockwidgets.xml
+++ b/python/PyKDDockWidgets/typesystem_kddockwidgets.xml
@@ -26,7 +26,6 @@
         <enum-type name="FrontendType" />
         <enum-type name="InitialVisibilityOption" />
         <enum-type name="RestoreOption" flags="RestoreOptions" />
-        <enum-type name="DropIndicatorType" />
         <enum-type name="SideBarLocation" />
         <enum-type name="TitleBarButtonType" />
         <enum-type name="DropLocation" />

--- a/python/PyKDDockWidgets/typesystem_kddockwidgets.xml
+++ b/python/PyKDDockWidgets/typesystem_kddockwidgets.xml
@@ -6,7 +6,6 @@
         typesystem because it already include gui and core typesystem -->
     <load-typesystem name="typesystem_widgets.xml" generate="no" />
 
-    <rejection class="KDDockWidgets" function-name="qt_getEnumName" />
     <rejection class="KDDockWidgets" function-name="qt_getEnumMetaObject" />
     <rejection class="KDDockWidgets" function-name="qt_getEnumName" />
 
@@ -28,22 +27,21 @@
         <enum-type name="InitialVisibilityOption" />
         <enum-type name="RestoreOption" flags="RestoreOptions" />
         <enum-type name="DropIndicatorType" />
-        <enum-type name="SizePolicy" />
         <enum-type name="SideBarLocation" />
         <enum-type name="TitleBarButtonType" />
         <enum-type name="DropLocation" />
         <enum-type name="DropIndicatorType" />
         <enum-type name="AddingOption" />
         <enum-type name="WindowState" flags="WindowStates" />
-
         <!-- Internal - just to avoid generation warning -->
         <enum-type name="SuggestedGeometryHint" flags="SuggestedGeometryHints" />
         <enum-type name="CursorPosition" flags="CursorPositions" />
         <enum-type name="FrameOption" flags="FrameOptions" />
         <enum-type name="StackOption" flags="StackOptions" />
         <enum-type name="FloatingWindowFlag" flags="FloatingWindowFlags" />
-        <enum-type name="FloatingWindowFlag" flags="FloatingWindowFlags" />
         <enum-type name="DefaultSizeMode" />
+        <enum-type name="CloseReason"/>
+        <enum-type name="NeighbourSqueezeStrategy"/>
 
         <!-- our classes
              For class we can use two types:
@@ -54,25 +52,32 @@
         <value-type name="InitialOption">
             <include file-name="kddockwidgets/KDDockWidgets.h" location="global"/>
         </value-type>
+        
         <object-type name="LayoutSaver">
             <include file-name="kddockwidgets/LayoutSaver.h" location="global"/>
         </object-type>
+        
         <object-type name="Config">
             <include file-name="kddockwidgets/Config.h" location="global"/>
-
+            
             <enum-type name="Flag" flags="Flags" />
             <enum-type name="CustomizableWidget" flags="CustomizableWidgets" />
             <enum-type name="InternalFlag" flags="InternalFlags" />
+            <enum-type name="MDIFlag" flags="MDIFlags"/>
         </object-type>
 
         <namespace-type name="Core" visible="no">
             <enum-type name="ViewType" />
-            <object-type name="DockWidgetViewInterface" >
-              <include file-name="kddockwidgets/core/views/DockWidgetViewInterface.h" location="global"/>
+            
+            <object-type name="DockWidgetViewInterface">
+                <include file-name="kddockwidgets/core/views/DockWidgetViewInterface.h" location="global"/>
+                <rejection class="KDDockWidgets::Core::DockWidgetViewInterface" field-name="m_dockWidget" />
             </object-type>
+            
             <object-type name="MainWindowViewInterface">
-              <include file-name="kddockwidgets/core/views/MainWindowViewInterface.h" location="global"/>
-              <modify-function signature="addDockWidget(KDDockWidgets::Core::DockWidgetViewInterface*,KDDockWidgets::Location,KDDockWidgets::Core::DockWidgetViewInterface*,KDDockWidgets::InitialOption)" rename="addKDockWidget" />
+                <include file-name="kddockwidgets/core/views/MainWindowViewInterface.h" location="global"/>
+                <rejection class="KDDockWidgets::Core::MainWindowViewInterface" field-name="m_mainWindow" />
+                <modify-function signature="addDockWidget(KDDockWidgets::Core::DockWidgetViewInterface*,KDDockWidgets::Location,KDDockWidgets::Core::DockWidgetViewInterface*,KDDockWidgets::InitialOption)" rename="addKDockWidget" />
             </object-type>
         </namespace-type>
 
@@ -80,9 +85,11 @@
             <object-type name="MainWindow">
                 <include file-name="kddockwidgets/qtwidgets/views/MainWindow.h" location="global"/>
             </object-type>
+            
             <object-type name="DockWidget">
                 <include file-name="kddockwidgets/qtwidgets/views/DockWidget.h" location="global"/>
             </object-type>
+            
         </namespace-type>
     </namespace-type>
 </typesystem>


### PR DESCRIPTION
Small fix, remove duplicate enum, add rejection value

Small contribution, not yet used to PR. Hope it can help

Buid with 6.8.1

```
**********************************************************************
** Visual Studio 2022 Developer Command Prompt v17.12.3
** Copyright (c) 2022 Microsoft Corporation
**********************************************************************
[vcvarsall.bat] Environment initialized for: 'x64'
Updating libclang.dll for Shiboken...
        1 fichier(s) copié(s).
-- The CXX compiler identification is MSVC 19.40.33817.0
-- The C compiler identification is MSVC 19.40.33817.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
No frontends specified explicitly.
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - not found
-- Found Threads: TRUE
-- Performing Test HAVE_STDATOMIC
-- Performing Test HAVE_STDATOMIC - Success
-- Found WrapAtomic: TRUE
-- Could NOT find WrapVulkanHeaders (missing: Vulkan_INCLUDE_DIR) 
-- Could NOT find WrapVulkanHeaders (missing: Vulkan_INCLUDE_DIR) 
Following frontends have been enabled:
* qtwidgets
* qtquick
-- Building KDDockWidgets 2.1.1 in Release mode. Installing to .venv/Lib/PyKDDockWidgets
-- nlohmann_json not found in system. Using our own bundled one
-- Found Python3: .venv/Scripts/python.exe (found suitable version "3.12.0", minimum required is "3.7") found components: Interpreter Development Development.Module Development.Embed
-- ShibokenGenerator base dir:.venv\Lib\site-packages\shiboken6_generator
-- Shiboken base dir:        .venv\Lib\site-packages\shiboken6
-- Shiboken custom path:
-- Shiboken include dir:      .venv/Lib/site-packages/shiboken6_generator/include
-- Shiboken library:           .venv/Lib/site-packages/shiboken6/shiboken6.abi3.lib
-- Shiboken binary:            .venv/Scripts/shiboken6.exe
-- Shiboken version:           6.8.1
-- Found Shiboken6: .venv\Lib\site-packages\shiboken6 (found version "6.8.1")
-- PySide6 base dir:         .venv\Lib\site-packages\PySide6
-- PySide6 suffix:             pyd.6.8
-- PySide include dir:         .venv/Lib/site-packages/PySide6/include
-- PySide library:             .venv/Lib/site-packages/PySide6/pyside6.abi3.lib
-- PySide typesystems:         .venv/Lib/site-packages/PySide6/typesystems
-- PySide6 version:            6.8.1
-- Found PySide6:.venv\Lib\site-packages\PySide6 (found suitable exact version "6.8.1")
-- PYTHON INSTALL PREFIX .venv/Lib//site-packages/PyKDDockWidgetsQt6
-- The following OPTIONAL packages have been found:

 * Qt6WidgetsTools (required version >= 6.8.1)
 * Qt6CoreTools (required version >= 6.8.1)
 * Qt6GuiTools (required version >= 6.8.1)
 * Qt6Widgets (required version >= 6.2.0)
 * Qt6QuickTools (required version >= 6.8.1)
 * Qt6QmlTools (required version >= 6.8.1)
 * Qt6Quick (required version >= 6.2.0)
 * Qt6QuickControls2 (required version >= 6.2.0)

-- The following REQUIRED packages have been found:

 * Python3 (required version >= 3.7)
 * Shiboken6
 * PySide6 (required version == 6.8.1)
 * Qt6

-- The following OPTIONAL packages have not been found:

 * Qt6QmlCompilerPlusPrivateTools (required version >= 2.1.1)
 * Vulkan
 * WrapVulkanHeaders
 * spdlog (required version >= 1.8.0)
 * fmt
 * nlohmann_json

-- Configuring done (3.9s)
-- Generating done (0.2s)
-- Build files have been written to: KDDockWidgets/build
(kddockwidgets) [1611ms] Generated enum model (6).                                   [OK]
(kddockwidgets) [1614ms] Generated namespace model (166).                            [OK]
(kddockwidgets) [1726ms] Resolved typedefs (109).                                    [OK]
(kddockwidgets) [1727ms] Fixed class inheritance.                                    [OK]
(kddockwidgets) [1756ms] Checked for inconsistencies in class model.                 [OK]
(kddockwidgets) [1782ms] Checked for inconsistencies in typesystem (5163).           [OK]
(kddockwidgets) [1782ms] Checked for inconsistencies in function modifications.      [OK]
(kddockwidgets) [1788ms] Wrote log files.                                            [OK]
(kddockwidgets) [1810ms] Ran Source generator.                                       [OK]
(kddockwidgets) [1815ms] Ran Header generator.                                       [OK]

```

