### PR TITLE
ci: Remove shiboken workarounds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,14 +87,6 @@ jobs:
         if: ${{ matrix.preset.pip_pgks }}
         run: echo ${{ join(matrix.preset.pip_pgks, ' ') }} | xargs pip install
 
-      - name: Hackery due Shiboken hardcoded paths
-        if: ${{ matrix.preset.pip_pgks }}
-        run: |
-          sudo mkdir -p /opt/rh/gcc-toolset-10/root/usr/bin/
-          sudo cp /usr/bin/g++-10 /opt/rh/gcc-toolset-10/root/usr/bin/c++
-          sudo mkdir -p /opt/rh/gcc-toolset-10/root/usr/lib/gcc/x86_64-linux-gnu/10/
-          sudo cp /usr/lib/gcc/x86_64-linux-gnu/10/cc1plus /opt/rh/gcc-toolset-10/root/usr/lib/gcc/x86_64-linux-gnu/10/
-
       - name: Install ninja-build tool (must be after Qt due PATH changes)
         uses: turtlesec-no/get-ninja@main
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,10 +66,16 @@ jobs:
 
     steps:
       - name: Install Qt ${{ matrix.preset.qt_version }} with options and default aqtversion
-        uses: jurplel/install-qt-action@v3
+        uses: jurplel/install-qt-action@v4
         with:
           version: ${{ matrix.preset.qt_version }}
           cache: true
+
+
+      - name: Set Qt env (workaround for self-hosted runners)
+        run: |
+          echo "${RUNNER_WORKSPACE}/Qt/${{ matrix.preset.qt_version }}/gcc_64/bin/" >> $GITHUB_PATH
+          echo $PATH
 
       - name: Install dependencies on Ubuntu (${{ join(matrix.preset.apt_pgks, ' ') }})
         if: ${{ runner.os == 'Linux' && matrix.preset.apt_pgks }}

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -28,11 +28,15 @@ jobs:
     env:
       MDBOOK_VERSION: 0.4.21
     steps:
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
       - uses: actions/checkout@v4
       - name: Install mdBook
         run: |
-          curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf -y | sh
-          rustup update
           cargo install --version ${MDBOOK_VERSION} mdbook
       - name: Setup Pages
         id: pages

--- a/.github/workflows/python_and_static.yml
+++ b/.github/workflows/python_and_static.yml
@@ -93,14 +93,6 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
         uses: ilammy/msvc-dev-cmd@v1
 
-      - name: Hackery due Shiboken hardcoded paths
-        if: ${{ runner.os == 'Linux' }}
-        run: |
-          sudo mkdir -p /opt/rh/gcc-toolset-10/root/usr/bin/
-          sudo cp /usr/bin/g++-10 /opt/rh/gcc-toolset-10/root/usr/bin/c++
-          sudo mkdir -p /opt/rh/gcc-toolset-10/root/usr/lib/gcc/x86_64-linux-gnu/10/
-          sudo cp /usr/lib/gcc/x86_64-linux-gnu/10/cc1plus /opt/rh/gcc-toolset-10/root/usr/lib/gcc/x86_64-linux-gnu/10/
-
       - name: Configure project
         run: cmake -S . -B ./build-${{ matrix.preset.name }} --preset ${{ matrix.preset.name }}
 

--- a/.github/workflows/qt6-asan.yml
+++ b/.github/workflows/qt6-asan.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: true
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-22.04
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/qt6-lsan.yml
+++ b/.github/workflows/qt6-lsan.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: true
 


### PR DESCRIPTION
ubuntu-latest was upgraded by GH, it no longer has gcc-10 Checking if workaround is still needed