### PR TITLE
Build for Qt6 by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@
 # Pass the following variables to cmake to control the build:
 #
 # -DKDDockWidgets_QT6=[true|false] Build against Qt6 rather than Qt5
-# Default=false (Qt5 will be used even if Qt6 is available)
+# Default=true
 #
 # -DKDDockWidgets_STATIC=[true|false] Build static versions of the libraries
 # Default=false
@@ -104,7 +104,7 @@ set(KDDockWidgets_LIBRARY_POSTFIX
     CACHE STRING "Appends the specified string to the library name. Not applicable to VS generator."
 )
 
-option(KDDockWidgets_QT6 "Build against Qt 6" OFF)
+option(KDDockWidgets_QT6 "Build against Qt 6" ON)
 option(KDDockWidgets_DEVELOPER_MODE "Developer Mode" OFF)
 option(KDDockWidgets_PYTHON_BINDINGS "Build python bindings" OFF)
 option(KDDockWidgets_STATIC "Build statically" OFF)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -68,20 +68,21 @@
     {
       "name": "dev-valgrind",
       "displayName": "dev-valgrind",
-      "description": "A dev preset which runs tests under valgrind",
+      "description": "A Qt5 dev preset which runs tests under valgrind",
       "binaryDir": "${sourceDir}/build-dev-valgrind",
       "inherits": [
         "dev"
       ],
       "cacheVariables": {
         "KDDockWidgets_USE_VALGRIND": "ON",
+        "KDDockWidgets_QT6": "OFF",
         "KDDockWidgets_NO_SPDLOG": "ON"
       }
     },
     {
       "name": "dev-valgrind6",
       "displayName": "dev-valgrind6",
-      "description": "A dev preset which runs tests under valgrind",
+      "description": "A Qt6 dev preset which runs tests under valgrind",
       "binaryDir": "${sourceDir}/build-dev-valgrind6",
       "inherits": [
         "dev6"
@@ -193,6 +194,7 @@
       "binaryDir": "${sourceDir}/build-clazy",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
+        "KDDockWidgets_QT6": "OFF",
         "KDDockWidgets_WERROR": "ON",
         "KDDockWidgets_EXAMPLES": "OFF",
         "KDDockWidgets_FRONTENDS": "qtwidgets;qtquick"
@@ -220,6 +222,7 @@
       "binaryDir": "${sourceDir}/build-release",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
+        "KDDockWidgets_QT6": "OFF",
         "CMAKE_UNITY_BUILD": "OFF",
         "KDDockWidgets_FRONTENDS": "qtwidgets;qtquick"
       }
@@ -231,6 +234,7 @@
       "binaryDir": "${sourceDir}/build-release-no-x11extras",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
+        "KDDockWidgets_QT6": "OFF",
         "CMAKE_UNITY_BUILD": "OFF",
         "KDDockWidgets_X11EXTRAS": "OFF",
         "KDDockWidgets_FRONTENDS": "qtwidgets;qtquick"
@@ -254,7 +258,10 @@
       "binaryDir": "${sourceDir}/build-python",
       "inherits": [
         "python-base"
-      ]
+      ],
+      "cacheVariables": {
+        "KDDockWidgets_QT6": "OFF"
+      }
     },
     {
       "name": "python6",
@@ -464,6 +471,7 @@
       "generator": "Ninja",
       "cacheVariables": {
         "KDDockWidgets_DEVELOPER_MODE": "ON",
+        "KDDockWidgets_QT6": "OFF",
         "CMAKE_BUILD_TYPE": "Debug",
         "KDDockWidgets_FRONTENDS": "qtwidgets;qtquick"
       }
@@ -476,6 +484,7 @@
       "generator": "Ninja",
       "cacheVariables": {
         "KDDockWidgets_DEVELOPER_MODE": "OFF",
+        "KDDockWidgets_QT6": "OFF",
         "CMAKE_BUILD_TYPE": "Release",
         "KDDockWidgets_FRONTENDS": "qtwidgets;qtquick"
       }
@@ -488,6 +497,7 @@
       "generator": "Ninja",
       "cacheVariables": {
         "KDDockWidgets_DEVELOPER_MODE": "OFF",
+        "KDDockWidgets_QT6": "OFF",
         "CMAKE_BUILD_TYPE": "Release",
         "KDDockWidgets_FRONTENDS": "qtwidgets"
       }
@@ -500,6 +510,7 @@
       "generator": "Ninja",
       "cacheVariables": {
         "KDDockWidgets_DEVELOPER_MODE": "OFF",
+        "KDDockWidgets_QT6": "OFF",
         "CMAKE_BUILD_TYPE": "Release",
         "KDDockWidgets_FRONTENDS": "qtquick"
       }
@@ -578,6 +589,7 @@
         "dev-valgrind"
       ],
       "cacheVariables": {
+        "KDDockWidgets_QT6": "OFF",
         "KDDockWidgets_FRONTENDS": "qtwidgets"
       }
     },
@@ -600,7 +612,10 @@
       "binaryDir": "${sourceDir}/build-ci-dev-asan-qt5",
       "inherits": [
         "dev-asan"
-      ]
+      ],
+      "cacheVariables": {
+        "KDDockWidgets_QT6": "OFF"
+      }
     },
     {
       "name": "ci-dev-asan-qt6",

--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,6 @@
 * v2.3.0
+  - KDDockWidgets now looks for Qt6 by default, rather than Qt5. If your Qt5
+    build broke, pass -DKDDockWidgets_QT6=OFF to CMake.
   - qtquick: Add QtQuick::IndicatorWindow::setQuickWindowCreationCallback
   - qtquick: Add support for building as a QML module and fixed all qmllint warnings
 * v2.2.1

--- a/docs/book/src/installation_and_usage.md
+++ b/docs/book/src/installation_and_usage.md
@@ -18,7 +18,7 @@
 
 You can skip building manually and instead consume KDDockWidgets via [vcpkg](#using-via-vcpkg).
 
-Although the build system supports many options, you'll mostly use `-DKDDockWidgets_QT6=ON`, or don't use any option, which defaults to `Qt 5`.
+Although the build system supports many options, you'll mostly use `-DKDDockWidgets_QT6=ON`, or `OFF` for `Qt 5`.
 
 By default, KDDW will be built with support for both `QtWidgets` and `QtQuick`. If you want to save some binary space and compile time,
 consider passing `-DKDDockWidgets_FRONTENDS="qtwidgets"` or `-DKDDockWidgets_FRONTENDS="qtquick"`.


### PR DESCRIPTION
If your Qt5 build broke, pass -DKDDockWidgets_QT6=OFF to CMake.