### PR TITLE
Fix some stray include directives

### DIFF
--- a/src/core/indicators/ClassicDropIndicatorOverlay.h
+++ b/src/core/indicators/ClassicDropIndicatorOverlay.h
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include "core/DropIndicatorOverlay.h"
+#include "kddockwidgets/core/DropIndicatorOverlay.h"
 
 namespace KDDockWidgets {
 

--- a/src/core/indicators/NullDropIndicatorOverlay.h
+++ b/src/core/indicators/NullDropIndicatorOverlay.h
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include "core/DropIndicatorOverlay.h"
+#include "kddockwidgets/core/DropIndicatorOverlay.h"
 
 namespace KDDockWidgets {
 


### PR DESCRIPTION
This makes it so you don't have to add an extra include path to implement custom drop indicators.