### PR TITLE
Add a flag making the persistant central widget getting all extra space

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -3,6 +3,7 @@
     build broke, pass -DKDDockWidgets_QT6=OFF to CMake.
   - qtquick: Add QtQuick::IndicatorWindow::setQuickWindowCreationCallback
   - qtquick: Add support for building as a QML module and fixed all qmllint warnings
+  - Add MainWindowOption_CentralWidgetGetsAllExtraSpace
 
 * v2.2.3
   - Fix potential crash found by ASAN

--- a/examples/dockwidgets/main.cpp
+++ b/examples/dockwidgets/main.cpp
@@ -205,6 +205,13 @@ int main(int argc, char **argv)
                                     "The main window will have a non-detachable central widget"));
     parser.addOption(centralWidget);
 
+    QCommandLineOption centralWidgetAllExtraSize(
+        "central-widget-all-extra-size",
+        QCoreApplication::translate("main",
+                                    "The main window will have a non-detachable central widget which "
+                                    "gets all the extra space when the window is enlarged (imples --central-widget"));
+    parser.addOption(centralWidgetAllExtraSize);
+
     QCommandLineOption tabsAtBottom("tabs-at-bottom", QCoreApplication::translate("main", "Shows tabs at bottom"));
     parser.addOption(tabsAtBottom);
 
@@ -275,6 +282,11 @@ int main(int argc, char **argv)
 
     if (parser.isSet(centralWidget))
         options |= MainWindowOption_HasCentralWidget;
+
+    if (parser.isSet(centralWidgetAllExtraSize)) {
+        options |= MainWindowOption_HasCentralWidget;
+        options |= MainWindowOption_CentralWidgetGetsAllExtraSpace;
+    }
 
     if (parser.isSet(noQtTool))
         internalFlags |= KDDockWidgets::Config::InternalFlag_DontUseQtToolWindowsForFloatingWindows;

--- a/src/KDDockWidgets.h
+++ b/src/KDDockWidgets.h
@@ -90,7 +90,8 @@ enum MainWindowOption {
     /// MainWindowBase::setPersistentCentralWidget()
     MainWindowOption_QDockWidgets = 8, ///> Allows the user to use QDockWidget instead of KDDW DockWidget, while using the KDDW MainWindow
                                        ///> Useful as a porting aid, where you want to migrate your main windows 1 by 1
-    MainWindowOption_ManualInit = 16 ///> For compatibility with setupUi() from UIC. See manualInit() for more details
+    MainWindowOption_ManualInit = 16, ///> For compatibility with setupUi() from UIC. See manualInit() for more details
+    MainWindowOption_CentralWidgetGetsAllExtraSpace = 32, ///> defines that all resize events to the main window lead to the central widget getting all extra space
 };
 Q_DECLARE_FLAGS(MainWindowOptions, MainWindowOption)
 Q_ENUM_NS(MainWindowOptions)

--- a/src/core/Group_p.h
+++ b/src/core/Group_p.h
@@ -115,6 +115,11 @@ public:
         return q->view()->d->freed();
     }
 
+    LayoutingGuestFlags flags() const override
+    {
+        return m_options & FrameOption_IsCentralFrame ? IsCentralFrame : None;
+    }
+
     Group *const q;
     int m_userType = 0;
     FrameOptions m_options = FrameOption_None;

--- a/src/core/Layout.cpp
+++ b/src/core/Layout.cpp
@@ -190,8 +190,15 @@ void Layout::unrefOldPlaceholders(const Core::Group::List &groupsBeingAdded) con
 void Layout::setLayoutSize(Size size)
 {
     if (size != layoutSize()) {
-        d->m_rootItem->setSize_recursive(size);
-        if (!d->m_inResizeEvent && !LayoutSaver::restoreInProgress())
+        const bool restoreInProgress = LayoutSaver::restoreInProgress();
+        ChildrenResizeStrategy strategy = ChildrenResizeStrategy::Percentage;
+        const auto *main = mainWindow();
+        if (!restoreInProgress && main && main->options() & MainWindowOption_CentralWidgetGetsAllExtraSpace)
+            strategy = ChildrenResizeStrategy::GiveDropAreaWithCentralFrameAllExtra;
+
+        d->m_rootItem->setSize_recursive(size, strategy);
+
+        if (!d->m_inResizeEvent && !restoreInProgress)
             view()->resize(size);
     }
 }

--- a/src/core/layouting/Item.cpp
+++ b/src/core/layouting/Item.cpp
@@ -2111,10 +2111,9 @@ void ItemBoxContainer::Private::resizeChildren(Size oldSize, Size newSize,
 
     std::function<int(const Item::List &)> indexOfCentralFrame;
     indexOfCentralFrame = [&indexOfCentralFrame](const Item::List &children) -> int {
-        const Item *centralFrame = nullptr;
         for (auto *child : children) {
             const auto *guest = child->guest();
-            const bool isCentralFrame = guest ? guest->flags() & IsCentralFrame : false;
+            const bool isCentralFrame = guest && (guest->flags() & IsCentralFrame);
             if (isCentralFrame) {
                 return children.indexOf(child);
             } else if (child->isContainer()) {

--- a/src/core/layouting/Item_p.h
+++ b/src/core/layouting/Item_p.h
@@ -57,7 +57,8 @@ enum class ChildrenResizeStrategy {
                 ///< percentage
     Side1SeparatorMove, ///< When resizing a container, it takes/adds space from Side1 children
                         ///< first
-    Side2SeparatorMove ///< When resizing a container, it takes/adds space from Side2 children first
+    Side2SeparatorMove, ///< When resizing a container, it takes/adds space from Side2 children first
+    GiveDropAreaWithCentralFrameAllExtra ///< When resizing a container, it gives all extra space to a drop area with central frame fix, otherwise same as Percentage
 };
 
 enum LayoutBorderLocation {

--- a/src/core/layouting/LayoutingGuest_p.h
+++ b/src/core/layouting/LayoutingGuest_p.h
@@ -23,6 +23,12 @@ namespace Core {
 class Item;
 class LayoutingHost;
 
+enum LayoutingGuestFlag {
+    None = 0,
+    IsCentralFrame = 1
+};
+Q_DECLARE_FLAGS(LayoutingGuestFlags, LayoutingGuestFlag)
+
 /// The interface graphical components need to implement in order to be hosted by a layout
 /// The layout engine doesn't know about any GUI, only about LayoutingHost and LayoutingGuest
 /// This allows to keep the layouting engine separate from the rest of KDDW and even
@@ -41,6 +47,11 @@ public:
     virtual void setHost(LayoutingHost *parent) = 0;
     virtual LayoutingHost *host() const = 0;
     virtual QString id() const = 0;
+
+    virtual LayoutingGuestFlags flags() const
+    {
+        return None;
+    }
 
     virtual bool freed() const
     {


### PR DESCRIPTION
Add the MainWindowOption MainWindowOption_CentralWidgetGetsAllExtraSpace which will, upon resize, give all extra space to the persistent central widget.