### PR TITLE
fix: Don't emit QAction::toggled twice when detaching tab

### DIFF
--- a/src/qtwidgets/Action.cpp
+++ b/src/qtwidgets/Action.cpp
@@ -25,8 +25,9 @@ Action::Action(Core::DockWidget *dw, const char *debugName)
         if (m_lastCheckedState != checked) {
             m_lastCheckedState = checked;
             if (!signalsBlocked()) {
-                KDDW_TRACE("Action::toggled({}) ; dw={} ; {}", checked, ( void * )d->dockWidget, d->debugName);
+                blockSignals(true); // user might call the QAction directly, so protect here as well
                 safeEmitSignal(d->toggled, checked);
+                blockSignals(false);
             }
         }
     });

--- a/tests/tst_docks.cpp
+++ b/tests/tst_docks.cpp
@@ -4646,10 +4646,7 @@ void TestDocks::tst_floatingAction()
         QVERIFY(!dock1->isFloating());
         QVERIFY(!dock2->isFloating());
 
-        {
-            SetExpectedWarning sew("Got exception in signal");
-            dock1->floatAction()->toggle();
-        }
+        dock1->floatAction()->toggle();
 
         QVERIFY(dock1->isFloating());
         QVERIFY(dock2->isFloating());


### PR DESCRIPTION
Amends 42cbf7cc8204.
Less warning noise and makes the test simpler.