### PR TITLE
fix: Don't emit QAction::toggled twice when detaching tab

### DIFF
--- a/src/qtwidgets/Action.cpp
+++ b/src/qtwidgets/Action.cpp
@@ -13,6 +13,7 @@
 #include "Action_p.h"
 #include "core/Action_p.h"
 #include "core/Logging_p.h"
+#include "core/Utils_p.h"
 
 using namespace KDDockWidgets::QtWidgets;
 
@@ -25,7 +26,7 @@ Action::Action(Core::DockWidget *dw, const char *debugName)
             m_lastCheckedState = checked;
             if (!signalsBlocked()) {
                 KDDW_TRACE("Action::toggled({}) ; dw={} ; {}", checked, ( void * )d->dockWidget, d->debugName);
-                d->toggled.emit(checked);
+                safeEmitSignal(d->toggled, checked);
             }
         }
     });

--- a/src/qtwidgets/Action.cpp
+++ b/src/qtwidgets/Action.cpp
@@ -25,8 +25,9 @@ Action::Action(Core::DockWidget *dw, const char *debugName)
         if (m_lastCheckedState != checked) {
             m_lastCheckedState = checked;
             if (!signalsBlocked()) {
-                KDDW_TRACE("Action::toggled({}) ; dw={} ; {}", checked, ( void * )d->dockWidget, d->debugName);
+                blockSignals(true); // user might call the QAction directly, so protect here as well
                 safeEmitSignal(d->toggled, checked);
+                blockSignals(false);
             }
         }
     });


### PR DESCRIPTION
Amends 42cbf7cc8204.
Less warning noise and makes the test simpler.

(cherry picked from commit 3069549e2a2c62d2e77361094ce729ce2b6bf456)