### PR TITLE
ci: Fix Qt version for clazy workflow

### DIFF
--- a/.github/workflows/python_clazy_tidy_valgrind.yml
+++ b/.github/workflows/python_clazy_tidy_valgrind.yml
@@ -33,7 +33,7 @@ jobs:
 
           - name: clazy
             build_preset_arg: "--preset=clazy"
-            qt_version: "5.15"
+            qt_version: "6.5.0"
 
           - name: ci-dev-valgrind-qt6
             qt_version: "6.5.*"


### PR DESCRIPTION
We bumped to Qt 6 in the preset already