### PR TITLE
Add flag to disable double-click

### DIFF
--- a/src/Config.h
+++ b/src/Config.h
@@ -131,6 +131,7 @@ public:
         Flag_AllowSwitchingTabsViaMenu = 0x80000, ///< Allow switching tabs via a context menu when
                                                   ///< right clicking on the tab area
         Flag_AutoHideAsTabGroups = 0x100000, ///< If tabbed dockwidgets are sent to/from sidebar, they're all sent and restored together
+        Flag_DisableDoubleClick = 0x200000, ///< Do not maximize of float if a title or tab is double-clicked.
         Flag_Default = Flag_AeroSnapWithClientDecos ///< The defaults
     };
     Q_DECLARE_FLAGS(Flags, Flag)

--- a/src/core/TabBar.cpp
+++ b/src/core/TabBar.cpp
@@ -223,7 +223,9 @@ void Core::TabBar::onMousePress(Point localPos)
 
 bool Core::TabBar::onMouseDoubleClick(Point localPos)
 {
-    if (DockWidget *dw = dockWidgetAt(localPos)) {
+    if (Config::self().flags() & Config::Flag_DisableDoubleClick) {
+        return false;
+    } else if (DockWidget *dw = dockWidgetAt(localPos)) {
         dw->setFloating(!dw->isFloating());
         return true;
     }

--- a/src/core/TitleBar.cpp
+++ b/src/core/TitleBar.cpp
@@ -167,7 +167,9 @@ Icon TitleBar::icon() const
 
 bool TitleBar::onDoubleClicked()
 {
-    if ((Config::self().flags() & Config::Flag_DoubleClickMaximizes) && m_floatingWindow) {
+    if (Config::self().flags() & Config::Flag_DisableDoubleClick) {
+        return false;
+    } else if ((Config::self().flags() & Config::Flag_DoubleClickMaximizes) && m_floatingWindow) {
         // Not using isFloating(), as that can be a dock widget nested in a floating window. By
         // convention it's floating, but it's not the title bar of the top-level window.
         toggleMaximized();


### PR DESCRIPTION
I've added an additional flag to Config which can be used to conditionally ignore `onMouseDoubleClick` events.
This was a suggested fix in #524 as one step toward making docking widgets non-floatable via user interaction.

I have tested these changes in a QML/qtquick application, but have not tried them out in flutter or qtwidgets.

Please let me know if you want me to extend any tests, I would be happy add those in a subsequent commit