### PR TITLE
qtwidgets: Don't steal ownership of qApp's QStyle

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -11,6 +11,7 @@
   - QtWidgets::ViewFactory::createTitleBarButton() is now virtual
   - Support window managers without translucency in Qt 6 (#629)
   - Add Config::Flag_DisableDoubleClick
+  - Don't steal QStyle ownership from QApplication
 
 * v2.2.5
   - Fix version being reported as 2.2.3

--- a/docs/book/src/custom_styling.md
+++ b/docs/book/src/custom_styling.md
@@ -28,3 +28,9 @@ See `examples/dockwidgets/MyViewFactory.h` for QtWidgets, or `examples/qtquick/c
 `Qt StyleSheets` are not, and will not, be supported. See the comments in
 `examples/dockwidgets/MyTitleBar_CSS.h` for why. You can however use some minimal
 CSS, as shown in that example, just don't report bugs about it.
+
+## Known Issues
+
+- tabbars use a `QProxyStyle` to workaround a Qt bug. That proxy style is based on the `QApplication`'s style.
+If you later change `QApplication`'s style, that won't propagate to the existing `QProxyStyle`. See possible
+workaround in https://github.com/KDAB/KDDockWidgets/issues/635

--- a/src/qtwidgets/views/TabBar.cpp
+++ b/src/qtwidgets/views/TabBar.cpp
@@ -36,7 +36,6 @@ class MyProxy : public QProxyStyle
     Q_OBJECT
 public:
     MyProxy()
-        : QProxyStyle(qApp->style())
     {
         setParent(qApp);
     }


### PR DESCRIPTION
QProxyStyle(QStyle*) overload will take ownership of the style.
Use the ctor overload that creates a new base style.

For #635