### PR TITLE
ci: Don't build ci-python-qt6 twice

### DIFF
--- a/.github/workflows/build-qt6.yml
+++ b/.github/workflows/build-qt6.yml
@@ -40,17 +40,6 @@ jobs:
           - name: ci-release-static-qt6
             qt_version: "6.3.*"
 
-        include:
-          - os: ubuntu-latest
-            preset:
-              name: ci-python-qt6
-              qt_version: "6.6.0"
-              detect_leaks: 0
-              apt_pgks:
-                - llvm
-              pip_pgks:
-                - shiboken6-generator==6.6.0 pyside6==6.6.0
-
     steps:
       - name: Export IS_SELFHOSTED
         run: echo "IS_SELFHOSTED=$IS_SELFHOSTED" >> $GITHUB_ENV
@@ -73,10 +62,6 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         run: |
           sudo apt install libspdlog-dev -y
-
-      - name: Install Python dependencies (${{ join(matrix.preset.pip_pgks, ' ') }})
-        if: ${{ matrix.preset.pip_pgks }}
-        run: echo ${{ join(matrix.preset.pip_pgks, ' ') }} | xargs pip install
 
       - name: Install ninja (Windows / Linux)
         if: ${{ runner.os != 'macOS' }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,12 +47,6 @@ repos:
         args: ["--line-width=1000"] # we don't care about line-width
       - id: cmake-format
         exclude: (.py.cmake|Doxyfile.cmake|examples/flutter/|tests/flutter/)
-  - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.18.1
-    hooks:
-      - id: markdownlint-cli2
-        files: \.(md|mdown|markdown)$
-        exclude: (docs/book/)
   - repo: https://github.com/fsfe/reuse-tool
     rev: v5.0.2
     hooks:


### PR DESCRIPTION
It's already coverted by python_clazy_tidy_valgrind.yml and was failing
since python wasn't being pinned to something less than 3.13