### PR TITLE
ci: Don't build ci-python-qt6 twice (#639)

### DIFF
--- a/.github/workflows/build-qt6.yml
+++ b/.github/workflows/build-qt6.yml
@@ -40,17 +40,6 @@ jobs:
           - name: ci-release-static-qt6
             qt_version: "6.3.*"
 
-        include:
-          - os: ubuntu-latest
-            preset:
-              name: ci-python-qt6
-              qt_version: "6.6.0"
-              detect_leaks: 0
-              apt_pgks:
-                - llvm
-              pip_pgks:
-                - shiboken6-generator==6.6.0 pyside6==6.6.0
-
     steps:
       - name: Export IS_SELFHOSTED
         run: echo "IS_SELFHOSTED=$IS_SELFHOSTED" >> $GITHUB_ENV
@@ -73,10 +62,6 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         run: |
           sudo apt install libspdlog-dev -y
-
-      - name: Install Python dependencies (${{ join(matrix.preset.pip_pgks, ' ') }})
-        if: ${{ matrix.preset.pip_pgks }}
-        run: echo ${{ join(matrix.preset.pip_pgks, ' ') }} | xargs pip install
 
       - name: Install ninja (Windows / Linux)
         if: ${{ runner.os != 'macOS' }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,12 +47,6 @@ repos:
         args: ["--line-width=1000"] # we don't care about line-width
       - id: cmake-format
         exclude: (.py.cmake|Doxyfile.cmake|examples/flutter/|tests/flutter/)
-  - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.18.1
-    hooks:
-      - id: markdownlint-cli2
-        files: \.(md|mdown|markdown)$
-        exclude: (docs/book/)
   - repo: https://github.com/fsfe/reuse-tool
     rev: v5.0.2
     hooks:

--- a/Changelog
+++ b/Changelog
@@ -12,6 +12,7 @@
   - Support window managers without translucency in Qt 6 (#629)
   - Add Config::Flag_DisableDoubleClick
   - Don't steal QStyle ownership from QApplication
+  - Added Core::DockWidget::setUserData(QVariantMap)
 
 * v2.2.5
   - Fix version being reported as 2.2.3

--- a/src/LayoutSaver.cpp
+++ b/src/LayoutSaver.cpp
@@ -333,6 +333,10 @@ static void to_json(nlohmann::json &json, const LayoutSaver::DockWidget &dw)
     json["uniqueName"] = dw.uniqueName;
     json["lastPosition"] = dw.lastPosition;
     json["lastCloseReason"] = dw.lastCloseReason;
+#ifdef KDDW_FRONTEND_QT
+    if (!dw.userData.isEmpty())
+        json["userData"] = dw.userData;
+#endif
 }
 
 static void from_json(const nlohmann::json &json, LayoutSaver::DockWidget &dw)
@@ -347,6 +351,15 @@ static void from_json(const nlohmann::json &json, LayoutSaver::DockWidget &dw)
 
     dw.lastPosition = jsonValue(json, "lastPosition", LayoutSaver::Position());
     dw.lastCloseReason = jsonValue(json, "lastCloseReason", CloseReason::Unspecified);
+    
+#ifdef KDDW_FRONTEND_QT
+    auto userDataIt = json.find("userData");
+    if (userDataIt != json.end()) {
+        QVariantMap userData;
+        from_json(*userDataIt, userData);
+        dw.userData = userData;
+    }
+#endif
 }
 
 static void to_json(nlohmann::json &json, const typename LayoutSaver::DockWidget::List &list)

--- a/src/LayoutSaver.cpp
+++ b/src/LayoutSaver.cpp
@@ -351,7 +351,7 @@ static void from_json(const nlohmann::json &json, LayoutSaver::DockWidget &dw)
 
     dw.lastPosition = jsonValue(json, "lastPosition", LayoutSaver::Position());
     dw.lastCloseReason = jsonValue(json, "lastCloseReason", CloseReason::Unspecified);
-    
+
 #ifdef KDDW_FRONTEND_QT
     auto userDataIt = json.find("userData");
     if (userDataIt != json.end()) {

--- a/src/core/DockWidget.cpp
+++ b/src/core/DockWidget.cpp
@@ -942,6 +942,9 @@ Core::DockWidget *DockWidget::deserialize(const LayoutSaver::DockWidget::Ptr &sa
         if (auto guest = dw->guestView())
             guest->setVisible(true);
         dw->d->m_wasRestored = true;
+#ifdef KDDW_FRONTEND_QT
+        dw->d->m_userData = saved->userData;
+#endif
 
         if (dw->affinities() != saved->affinities) {
             KDDW_ERROR("Affinity name changed from {} to {}", dw->affinities(), "; to", saved->affinities);
@@ -963,6 +966,18 @@ int DockWidget::userType() const
 {
     return d->m_userType;
 }
+
+#ifdef KDDW_FRONTEND_QT
+void DockWidget::setUserData(const QVariantMap &userData)
+{
+    d->m_userData = userData;
+}
+
+QVariantMap DockWidget::userData() const
+{
+    return d->m_userData;
+}
+#endif
 
 void DockWidget::setMDIPosition(Point pos)
 {
@@ -1016,6 +1031,9 @@ LayoutSaver::DockWidget::Ptr DockWidget::Private::serialize() const
     auto ptr = LayoutSaver::DockWidget::dockWidgetForName(q->uniqueName());
     ptr->affinities = q->affinities();
     ptr->lastCloseReason = m_lastCloseReason;
+#ifdef KDDW_FRONTEND_QT
+    ptr->userData = m_userData;
+#endif
 
     return ptr;
 }

--- a/src/core/DockWidget.h
+++ b/src/core/DockWidget.h
@@ -456,6 +456,16 @@ public:
     void setUserType(int userType);
     int userType() const;
 
+#ifdef KDDW_FRONTEND_QT
+    /// @brief Sets user data that can be attached to this dock widget
+    /// The user data is serialized when using LayoutSaver and can be retrieved with userData().
+    /// KDDW does not read or care about the contents of this data.
+    void setUserData(const QVariantMap &userData);
+
+    /// @brief Returns the user data attached to this dock widget
+    QVariantMap userData() const;
+#endif
+
     /// @brief Sets this dock widgets position to pos within the MDI layout
     /// This only applies if the main window is in MDI mode, which it is not by default
     void setMDIPosition(Point pos);

--- a/src/core/DockWidget_p.h
+++ b/src/core/DockWidget_p.h
@@ -296,6 +296,9 @@ public:
     KDBindings::ScopedConnection m_toggleActionConnection;
     KDBindings::ScopedConnection m_floatActionConnection;
     CloseReason m_lastCloseReason = CloseReason::Unspecified;
+#ifdef KDDW_FRONTEND_QT
+    QVariantMap m_userData;
+#endif
 };
 
 }

--- a/src/core/LayoutSaver_p.h
+++ b/src/core/LayoutSaver_p.h
@@ -136,6 +136,9 @@ struct DOCKS_EXPORT LayoutSaver::DockWidget
     Vector<QString> affinities;
     LayoutSaver::Position lastPosition;
     CloseReason lastCloseReason;
+#ifdef KDDW_FRONTEND_QT
+    QVariantMap userData;
+#endif
 
 private:
     DockWidget()

--- a/tests/qtwidgets/tst_qtwidgets.cpp
+++ b/tests/qtwidgets/tst_qtwidgets.cpp
@@ -239,6 +239,7 @@ private Q_SLOTS:
     void tst_complex();
     void tst_restoreFloatingMaximizedState();
     void tst_findAncestor();
+    void tst_userData();
 };
 
 void TestQtWidgets::tst_designerMainWindow()
@@ -2139,6 +2140,53 @@ void TestQtWidgets::tst_findAncestor()
 
     QCOMPARE(mainWindow, KDDockWidgets::findAncestor<QMainWindow>(mainWindow));
     QCOMPARE(mainWindow, KDDockWidgets::findAncestor<QMainWindow>(dockWidget));
+}
+
+void TestQtWidgets::tst_userData()
+{
+    QByteArray saved;
+
+    QVariantMap userData1;
+    userData1["key1"] = "value1";
+    userData1["key2"] = 123;
+    userData1["key3"] = true;
+
+    QVariantMap userData2;
+    userData2["name"] = "Test Dock";
+    userData2["priority"] = 5;
+    userData2["nested"] = QVariantMap { { "subkey", "subvalue" } };
+
+    {
+        EnsureTopLevelsDeleted e;
+        auto m = createMainWindow({}, {}, "mw1");
+
+        auto dock1 = createDockWidget("dock1");
+        dock1->setUserData(userData1);
+
+        auto dock2 = createDockWidget("dock2");
+        dock2->setUserData(userData2);
+
+        QCOMPARE(dock1->userData(), userData1);
+        QCOMPARE(dock2->userData(), userData2);
+
+        LayoutSaver saver;
+        saved = saver.serializeLayout();
+    }
+
+    EnsureTopLevelsDeleted e;
+
+    QVERIFY(!saved.isEmpty());
+
+    auto m = createMainWindow({}, {}, "mw1");
+
+    auto dock1 = createDockWidget("dock1");
+    auto dock2 = createDockWidget("dock2");
+
+    LayoutSaver restorer;
+
+    QVERIFY(restorer.restoreLayout(saved));
+    QCOMPARE(dock1->userData(), userData1);
+    QCOMPARE(dock2->userData(), userData2);
 }
 
 void TestQtWidgets::tst_standaloneTitleBar()


### PR DESCRIPTION
* ci: Don't build ci-python-qt6 twice

It's already coverted by python_clazy_tidy_valgrind.yml and was failing
since python wasn't being pinned to something less than 3.13

* remove markdownlint lint

I don't think it adds enough value and frequently gets in the way