### PR TITLE
wayland: Fix crash when setDropIndicatorAllowedFunc() is used

### DIFF
--- a/src/core/DragController.cpp
+++ b/src/core/DragController.cpp
@@ -1027,13 +1027,15 @@ std::shared_ptr<View> DragController::qtTopLevelUnderCursor() const
         // as it's a parent (TODO: How will it work with multiple MainWindows ?) The floating window
         // list is sorted by z-order, as we catch QEvent::Expose and move it to last of the list
 
-        View *tlwBeingDragged = m_windowBeingDragged->floatingWindow()->view();
-        if (auto tl = qtTopLevelUnderCursor_impl(
-                globalPos, DockRegistry::self()->floatingQWindows(), tlwBeingDragged))
-            return tl;
+        FloatingWindow *floatingWindow = m_windowBeingDragged->floatingWindow();
+        if (floatingWindow) {
+            if (auto tl = qtTopLevelUnderCursor_impl(
+                    globalPos, DockRegistry::self()->floatingQWindows(), floatingWindow->view()))
+                return tl;
 
-        return qtTopLevelUnderCursor_impl(
-            globalPos, DockRegistry::self()->topLevels(/*excludeFloatingDocks=*/true), tlwBeingDragged);
+            return qtTopLevelUnderCursor_impl(
+                globalPos, DockRegistry::self()->topLevels(/*excludeFloatingDocks=*/true), floatingWindow->view());
+        }
     }
 
     KDDW_TRACE("No top-level found");


### PR DESCRIPTION
There is crash due to a nullptr access when
KDDockWidgets::Config::setDropIndicatorAllowedFunc() is used and the applications runs with the Wayland platform plugin.

How to reproduce:

  - Start the qtwidgets_dockwidgets example with the Wayland platform plugin and the flag --hide-certain-docking-indicators.

  - Start dragging any dock widget. Exception: Dragging dock widgets in a floating dock widget which contains tabbed widgets only (e.g. undock the dock widget containing "DockWidget `#3/#5`", and drag the tabs).

Add nullptr check to fix the issue.