### PR TITLE
Export IndicatorWindow for setQuickWindowCreationCallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ to expose every internal widget and every knob for the app developer to tune.
 
 ## Showcases
 
-Read about how [NVIDIA implemented KDDockWidgets](https://www.kdab.com/why-kdab/proven-excellence/nvidia-improved-developer-tools-with-kddockwidgets/) in their their NSight Suite developer toolkit, which is built with Qt. 
+Read about how [NVIDIA implemented KDDockWidgets](https://www.kdab.com/why-kdab/proven-excellence/nvidia-improved-developer-tools-with-kddockwidgets/) in their their NSight Suite developer toolkit, which is built with Qt.
 
 ## Licensing
 

--- a/src/qtquick/views/ClassicIndicatorsWindow.h
+++ b/src/qtquick/views/ClassicIndicatorsWindow.h
@@ -29,7 +29,7 @@ namespace QtQuick {
 using IndicatorWindowCreationCallback = std::function<void(QQuickView *window)>;
 class ClassicDropIndicatorOverlay;
 
-class IndicatorWindow : public QQuickView
+class DOCKS_EXPORT IndicatorWindow : public QQuickView
 {
     Q_OBJECT
 public:


### PR DESCRIPTION
`IndicatorWindow` is currently not exported so `IndicatorWindow::setQuickWindowCreationCallback` in inaccessible