### PR TITLE
Basic functionnality for tabs in South mode

### DIFF
--- a/src/qtwidgets/views/Stack.cpp
+++ b/src/qtwidgets/views/Stack.cpp
@@ -228,12 +228,15 @@ Core::Stack *Stack::stack() const
 
 bool Stack::isPositionDraggable(QPoint p) const
 {
-    if (tabPosition() != QTabWidget::North) {
-        qWarning() << Q_FUNC_INFO << "Not implemented yet. Only North is supported";
-        return false;
+    switch (tabPosition()) {
+        case QTabWidget::North:
+            return p.y() >= 0 && p.y() <= tabBar()->height();
+        case QTabWidget::South:
+            return p.y() >= tabBar()->y();
+        default:
+            qWarning() << Q_FUNC_INFO << "Not implemented yet. Only North and South is supported";
+            return false;
     }
-
-    return p.y() >= 0 && p.y() <= tabBar()->height();
 }
 
 QAbstractButton *Stack::button(TitleBarButtonType type) const

--- a/src/qtwidgets/views/Stack.cpp
+++ b/src/qtwidgets/views/Stack.cpp
@@ -229,13 +229,13 @@ Core::Stack *Stack::stack() const
 bool Stack::isPositionDraggable(QPoint p) const
 {
     switch (tabPosition()) {
-        case QTabWidget::North:
-            return p.y() >= 0 && p.y() <= tabBar()->height();
-        case QTabWidget::South:
-            return p.y() >= tabBar()->y();
-        default:
-            qWarning() << Q_FUNC_INFO << "Not implemented yet. Only North and South is supported";
-            return false;
+    case QTabWidget::North:
+        return p.y() >= 0 && p.y() <= tabBar()->height();
+    case QTabWidget::South:
+        return p.y() >= tabBar()->y();
+    default:
+        qWarning() << Q_FUNC_INFO << "Not implemented yet. Only North and South is supported";
+        return false;
     }
 }
 

--- a/src/qtwidgets/views/TabBar.cpp
+++ b/src/qtwidgets/views/TabBar.cpp
@@ -84,6 +84,7 @@ TabBar::TabBar(Core::TabBar *controller, QWidget *parent)
     , TabBarViewInterface(controller)
     , d(new Private(controller))
 {
+    setShape(Config::self().tabsAtBottom() ? QTabBar::RoundedSouth : QTabBar::RoundedNorth);
     setStyle(proxyStyle());
 }
 


### PR DESCRIPTION
This changes the tabs drawing to correctly handle the South position, and allow dragging from the tabbar