### PR TITLE
cmake: Add KDDockWidgets_ENABLE_HARDENED option

### DIFF
--- a/.github/workflows/build-qt6.yml
+++ b/.github/workflows/build-qt6.yml
@@ -29,6 +29,8 @@ jobs:
         preset:
           - name: ci-dev-qt6
             qt_version: "6.10.0"
+          - name: ci-hardened
+            qt_version: "6.10.0"
           - name: ci-release-qt6
             qt_version: "6.3.*"
           - name: ci-qtwidgets-qt6

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,7 @@ option(KDDockWidgets_NO_SPDLOG "Don't use spdlog, even if it is found." OFF)
 option(KDDockWidgets_USE_LLD "Use lld for linking" OFF)
 option(KDDockWidgets_USE_VALGRIND "Runs the tests under valgrind" OFF)
 option(KDDockWidgets_QML_MODULE "The QtQuick support will be built as a QML module" OFF)
+option(KDDockWidgets_ENABLE_HARDENED "Enable -fhardened equivalent for GCC" OFF)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/ECM/modules")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/KDAB/modules")
@@ -163,11 +164,17 @@ else()
     set(QT_MIN_VERSION "5.15")
 endif()
 
-if(KDDockWidgets_DEVELOPER_MODE
-   AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
-   AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "14.1"
-)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fhardened -O1")
+if(KDDockWidgets_ENABLE_HARDENED)
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        set(CMAKE_CXX_FLAGS
+            "${CMAKE_CXX_FLAGS} -O2 -D_FORTIFY_SOURCE=3 -D_GLIBCXX_ASSERTIONS -fPIE  -pie -Wl,-z,now -Wl,-z,relro -fstack-protector-strong -fstack-clash-protection -fcf-protection=full"
+        )
+        if(KDDockWidgets_DEVELOPER_MODE)
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftrivial-auto-var-init=pattern")
+        else()
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftrivial-auto-var-init=zero")
+        endif()
+    endif()
 endif()
 
 # BEGIN frontend enabling

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -566,6 +566,18 @@
       }
     },
     {
+      "name": "ci-hardened",
+      "inherits": [
+        "ci-release-qt6"
+      ],
+      "description": "gcc fhardened build",
+      "binaryDir": "${sourceDir}/build-ci-hardened",
+      "cacheVariables": {
+        "KDDockWidgets_ENABLE_HARDENED": "ON",
+        "KDDockWidgets_DEVELOPER_MODE": "ON"
+      }
+    },
+    {
       "name": "ci-release-qt6",
       "description": "Qt6 non dev-mode",
       "displayName": "ci-release-qt6",

--- a/Changelog
+++ b/Changelog
@@ -3,6 +3,7 @@
   - qtquick: Expose 'DockWidget::lastCloseReason' to QML
   - qtquick: Add DockWidgetInstantiator::deleteDockWidgetLater
   - qtwidgets: Support tabs in south location
+  - cmake: Add -DKDDockWidgets_ENABLE_HARDENED (default OFF). Follows Qt and adds -fhardened on supported compilers.
 
 * v2.3.0
   - For packagers:


### PR DESCRIPTION
Defaults to OFF. Enables the equivalent of -fhardened. We add the individual options since gcc is a bit buggy if -fhardened is specified.