### PR TITLE
Do not get X11 info on Android

### DIFF
--- a/src/qtwidgets/views/ClassicIndicatorsWindow.cpp
+++ b/src/qtwidgets/views/ClassicIndicatorsWindow.cpp
@@ -24,7 +24,7 @@
 
 #ifdef QT_X11EXTRAS_LIB
 #include <QtX11Extras/QX11Info>
-#elif QT_VERSION >= QT_VERSION_CHECK(6, 0, 0) && defined(Q_OS_LINUX)
+#elif QT_VERSION >= QT_VERSION_CHECK(6, 0, 0) && defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
 #include <QtGui/private/qtx11extras_p.h>
 #endif
 
@@ -45,7 +45,7 @@ static bool windowManagerHasTranslucency()
         || (Config::self().internalFlags() & Config::InternalFlag_DisableTranslucency))
         return false;
 
-#if defined(QT_X11EXTRAS_LIB) || (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0) && defined(Q_OS_LINUX))
+#if defined(QT_X11EXTRAS_LIB) || (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0) && defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID))
     if (isXCB())
         return QX11Info::isCompositingManagerRunning();
 #endif


### PR DESCRIPTION
I am attempting to update the version of KDDockWidgets in vcpkg to 2.4.0 (https://github.com/microsoft/vcpkg/pull/48822) and extend the package to also build the qtquick frontend if requested, and have run into an issue with the Android build. The current build of 2.1.0 only builds the qtwidgets frontend and includes an Android build.

After updating to 2.4.0, I run into the problem that the check for X11 header in Qt6 is gated behind `Q_OS_LINUX`, which is also defined on Android but the private header is not available there. I can make this compile by extending the check in ClassicIndicatorsWindow.cpp to explicitly exclude Android, i.e. this pull request.

However I am not an Android developer, so I have no idea if the result of doing this is usable: if you say that this does not work, I will exclude Android from the list of supported platforms. (I would then want to know if qtquick works on Android to determine whether or not I should mark the whole package unsupported, or just the qtwidgets feature).