### PR TITLE
TabBar: use application style as base for proxy style

### DIFF
--- a/src/qtwidgets/views/TabBar.cpp
+++ b/src/qtwidgets/views/TabBar.cpp
@@ -36,6 +36,7 @@ class MyProxy : public QProxyStyle
     Q_OBJECT
 public:
     MyProxy()
+        : QProxyStyle(qApp->style())
     {
         setParent(qApp);
     }


### PR DESCRIPTION
So we don't lose the application style, in case the user has set it.