### PR TITLE
Fix separator position when using lazy mode without a parent

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,6 @@
 * v2.5.0
   - qtquick: Fixed support for one window with multiple docking areas
+  - qtwidgets: Fixed separator position when using lazy separators
 
 * v2.4.0
   - qtquick: Expose DockWidgetOptions to QML

--- a/src/core/Separator.cpp
+++ b/src/core/Separator.cpp
@@ -106,7 +106,7 @@ Separator::Separator(LayoutingHost *host, Qt::Orientation orientation, Core::Ite
     view()->show();
     view()->init();
     d->lazyResizeRubberBand = d->usesLazyResize ? Config::self().viewFactory()->createRubberBand(
-                                                      rubberBandIsTopLevel() ? nullptr : view())
+                                                      rubberBandIsTopLevel() ? nullptr : viewForLayoutingHost(host))
                                                 : nullptr;
     setVisible(true);
 }
@@ -156,8 +156,10 @@ void Separator::setLazyPosition(int pos)
         geo.moveLeft(pos);
     }
 
-    if (rubberBandIsTopLevel() && Platform::instance()->isQtWidgets())
-        geo.translate(view()->mapToGlobal(Point(0, 0)));
+    if (rubberBandIsTopLevel() && Platform::instance()->isQtWidgets()) {
+        if (auto parent = view()->parentView())
+            geo.translate(parent->mapToGlobal(Point(0, 0)));
+    }
     d->lazyResizeRubberBand->setGeometry(geo);
 }
 
@@ -175,7 +177,7 @@ void Separator::onMousePress()
     if (d->lazyResizeRubberBand) {
         setLazyPosition(position());
         d->lazyResizeRubberBand->show();
-        if (rubberBandIsTopLevel() && Platform::instance()->isQtWidgets())
+        if (Platform::instance()->isQtWidgets())
             d->lazyResizeRubberBand->raise();
     }
 }


### PR DESCRIPTION
Bug was repro with:
   auto flags = KDDockWidgets::Config::self().flags();
   flags |= KDDockWidgets::Config::Flag_LazyResize;
   KDDockWidgets::Config::self().setFlags(flags);

   auto internalFlags = KDDockWidgets::Config::self().internalFlags();
   internalFlags |= KDDockWidgets::Config::InternalFlag_TopLevelIndicatorRubberBand;
   KDDockWidgets::Config::self().setInternalFlags(internalFlags);