### PR TITLE
Main window. Fixed handle event filters

### DIFF
--- a/src/qtquick/views/MainWindow.cpp
+++ b/src/qtquick/views/MainWindow.cpp
@@ -69,6 +69,8 @@ MainWindow::MainWindow(const QString &uniqueName, MainWindowOptions options,
     auto layoutView = asView_qtquick(lw->view());
     makeItemFillParent(layoutView);
 
+    QQuickItem::window()->installEventFilter(this);
+
     // MainWindowQuick has the same constraints as Layout, so just forward the signal
     d->layoutGeometryChangedConnection = connect(layoutView, &View::geometryUpdated, this,
                                                  [this] {


### PR DESCRIPTION
Events aren't processed for the Main Window because we don't set an event filter (btw we do set an event filter for the FloatingWindow).

The event filter is important for the window: for example, in View::eventFilter we update normalGeometry. But since we stopped updating it, if the user closes the program in fullscreen mode, the window will have a size of 0x0 when the program is reopened.