### PR TITLE
ci: Fix Qt5 build by using older MSVC

### DIFF
--- a/.github/workflows/build-qt5.yml
+++ b/.github/workflows/build-qt5.yml
@@ -59,6 +59,8 @@ jobs:
       - name: Make sure MSVC is found when Ninja generator is in use
         if: ${{ runner.os == 'Windows' }}
         uses: ilammy/msvc-dev-cmd@v1
+        with:
+          toolset: 14.4 # newer MSVC doesn't build Qt5 (qvector.h(960): error C2653: 'stdext': is not a class or namespace name)
 
       - name: Configure project
         run: cmake -S . -B ./build-${{ matrix.preset.name }} --preset ${{ matrix.preset.name }}


### PR DESCRIPTION
qvector.h(960): error C2653: 'stdext': is not a class or namespace name

Newer MSVC has removed these symbols.