### PR TITLE
Fix QtQuick backend not deleting tab views on window close

### DIFF
--- a/src/qtquick/views/FloatingWindow.cpp
+++ b/src/qtquick/views/FloatingWindow.cpp
@@ -64,7 +64,17 @@ public:
 
     bool event(QEvent *ev) override
     {
-        if (ev->type() == QEvent::FocusAboutToChange) {
+        if (ev->type() == QEvent::Close) {
+            // Mirror the QtWidgets frontend (View<T>::closeEvent()): route the
+            // native window close (Alt+F4, taskbar, QWindow::close()) into
+            // KDDW, so the contained dock widgets are closed -- honouring
+            // e.g. DockWidgetOption_DeleteOnClose -- or the close is vetoed.
+            // Without this the window merely hides, leaving the dock widgets
+            // and their guest items alive.
+            m_view->Core::View::d->requestClose(static_cast<QCloseEvent *>(ev));
+            if (!ev->isAccepted())
+                return true; // vetoed (e.g. a non-closable dock widget)
+        } else if (ev->type() == QEvent::FocusAboutToChange) {
             // qquickwindow.cpp::event(FocusAboutToChange) removes the item grabber. Inibit that
             return true;
         } else if (ev->type() == QEvent::Resize) {

--- a/src/qtquick/views/MainWindow.cpp
+++ b/src/qtquick/views/MainWindow.cpp
@@ -12,6 +12,7 @@
 #include "MainWindow.h"
 #include "core/Layout.h"
 #include "core/MainWindow.h"
+#include "core/View_p.h"
 #include "core/Window_p.h"
 #include "core/Logging_p.h"
 #include "core/DockRegistry.h"
@@ -21,6 +22,8 @@
 #include "kddockwidgets/qtquick/views/View.h"
 
 #include <QQuickItem>
+#include <QQuickWindow>
+#include <QPointer>
 #include <QDebug>
 #include <QTimer>
 
@@ -51,6 +54,9 @@ public:
 
     MainWindow *const q;
     QMetaObject::Connection layoutGeometryChangedConnection;
+
+    /// The host QWindow currently being filtered for close events.
+    QPointer<QQuickWindow> closeFilterTarget;
 };
 }
 
@@ -64,6 +70,15 @@ MainWindow::MainWindow(const QString &uniqueName, MainWindowOptions options,
 {
     m_mainWindow->init(uniqueName);
     makeItemFillParent(this);
+
+    // If we were constructed with a parent that is already in a scene, the
+    // ItemSceneChange notification happened during the base QQuickItem
+    // constructor and never reached our itemChange() override; seed the
+    // close filter here. Later scene changes are handled by itemChange().
+    if (QQuickWindow *w = QQuickItem::window()) {
+        d->closeFilterTarget = w;
+        w->installEventFilter(this);
+    }
 
     Core::Layout *lw = m_mainWindow->layout();
     auto layoutView = asView_qtquick(lw->view());
@@ -87,6 +102,40 @@ MainWindow::MainWindow(const QString &uniqueName, MainWindowOptions options,
         Core::Item::s_silenceSanityChecks = true;
         timer->callOnTimeout([] { Core::Item::s_silenceSanityChecks = false; });
     }
+}
+
+void MainWindow::itemChange(QQuickItem::ItemChange change, const QQuickItem::ItemChangeData &data)
+{
+    // Follow the host window so eventFilter() sees its close events. Unlike
+    // the QtWidgets frontend, the main window view is not itself the
+    // top-level, so it doesn't receive close events directly. (itemChange is
+    // used rather than the windowChanged signal because it is not delivered
+    // to this subclass during destruction.)
+    if (change == QQuickItem::ItemSceneChange) {
+        // QQuickItem::window() is already updated at this point and equals
+        // ItemChangeData::window; using it avoids accessing the union.
+        if (d->closeFilterTarget)
+            d->closeFilterTarget->removeEventFilter(this);
+        d->closeFilterTarget = QQuickItem::window();
+        if (d->closeFilterTarget)
+            d->closeFilterTarget->installEventFilter(this);
+    }
+
+    View::itemChange(change, data);
+}
+
+bool MainWindow::eventFilter(QObject *watched, QEvent *ev)
+{
+    if (watched == d->closeFilterTarget && ev->type() == QEvent::Close) {
+        // Route the host window's native close (Alt+F4, taskbar,
+        // QWindow::close()) into KDDW so the layout can close its dock
+        // widgets -- honouring DockWidgetOption_DeleteOnClose -- or veto.
+        Core::View::d->requestClose(static_cast<QCloseEvent *>(ev));
+        if (!ev->isAccepted())
+            return true; // vetoed (e.g. a non-closable dock widget)
+    }
+
+    return View::eventFilter(watched, ev);
 }
 
 MainWindow::~MainWindow()

--- a/src/qtquick/views/MainWindow.h
+++ b/src/qtquick/views/MainWindow.h
@@ -83,6 +83,13 @@ public:
 #endif
 
 protected:
+    /// The main window view is an item inside an application-owned QWindow.
+    /// Filters that window's QEvent::Close into KDDW (mirroring the QtWidgets
+    /// frontend, where MainWindow is itself the top-level widget and receives
+    /// closeEvent() directly), so the layout closes its dock widgets or vetoes.
+    bool eventFilter(QObject *watched, QEvent *ev) override;
+    void itemChange(QQuickItem::ItemChange change, const QQuickItem::ItemChangeData &data) override;
+
     QMargins centerWidgetMargins() const override;
     QRect centralAreaGeometry() const override;
     void setContentsMargins(int left, int top, int right, int bottom) override;

--- a/tests/qtquick/tst_qtquick.cpp
+++ b/tests/qtquick/tst_qtquick.cpp
@@ -32,6 +32,7 @@
 #include "../fatal_logger.h"
 #endif
 
+#include <QPointer>
 #include <QtTest/QTest>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
@@ -67,6 +68,15 @@ private Q_SLOTS:
     void tst_affinities();
 
     void tst_deleteDockWidget();
+
+    /// A native close of a floating window's QWindow (Alt+F4, taskbar,
+    /// QWindow::close()) must close the contained dock widgets, honouring
+    /// DockWidgetOption_DeleteOnClose, instead of just hiding the window.
+    void tst_floatingWindowNativeClose();
+
+    /// Same as tst_floatingWindowNativeClose, but for the application-owned
+    /// window hosting a MainWindow: closing it must close the docked widgets.
+    void tst_mainWindowNativeClose();
     void tst_setViewFactory();
     void tst_quickWindowCreationCallback();
 };
@@ -487,6 +497,55 @@ void TestQtQuick::tst_deleteDockWidget()
 
     // 1 event loop iteration so we don't have memory leaks
     QTest::qWait(1);
+}
+
+void TestQtQuick::tst_floatingWindowNativeClose()
+{
+    EnsureTopLevelsDeleted e;
+    QQmlApplicationEngine engine(":/main465.qml"); // or any other main.qml
+
+    QPointer<Core::DockWidget> dock0 = createDockWidget(
+        "dock0", Platform::instance()->tests_createView({ true, {}, QSize(400, 400) }),
+        DockWidgetOption_DeleteOnClose);
+    QVERIFY(dock0->isFloating());
+
+    Core::FloatingWindow *fw = dock0->floatingWindow();
+    QVERIFY(fw);
+
+    QWindow *window = QtCommon::View_qt::asQQuickItem(fw->view())->window();
+    QVERIFY(window);
+
+    // Close the QWindow directly, like the window system would, rather than
+    // going through KDDW's title bar.
+    window->close();
+
+    // DockWidgetOption_DeleteOnClose deletes via deleteLater().
+    QTRY_VERIFY(dock0.isNull());
+}
+
+void TestQtQuick::tst_mainWindowNativeClose()
+{
+    EnsureTopLevelsDeleted e;
+    QQmlApplicationEngine engine(":/main2.qml");
+
+    const auto mainWindows = DockRegistry::self()->mainwindows();
+    QCOMPARE(mainWindows.size(), 1);
+    MainWindow *m = mainWindows.first();
+
+    QPointer<Core::DockWidget> dock0 = createDockWidget(
+        "dock0", Platform::instance()->tests_createView({ true, {}, QSize(400, 400) }),
+        DockWidgetOption_DeleteOnClose);
+    m->addDockWidget(dock0, Location_OnLeft);
+    QVERIFY(!dock0->isFloating());
+
+    QWindow *window = QtCommon::View_qt::asQQuickItem(m->view())->window();
+    QVERIFY(window);
+
+    // Close the host QWindow directly, like the window system would.
+    window->close();
+
+    // DockWidgetOption_DeleteOnClose deletes via deleteLater().
+    QTRY_VERIFY(dock0.isNull());
 }
 
 void TestQtQuick::tst_effectiveVisibilityBug()


### PR DESCRIPTION
I ran into an issue today where I noticed that none of my KDDW tabs were deleting the QML items I had them showing when I closed their windows (via window X button, alt F4, etc) despite having `KDDockWidgets::DockWidgetOption_DeleteOnClose` set. I dug into it a little bit (with Claude) and here are the findings:

The QtWidgets frontend routes native close events into KDDW via `View<T>::closeEvent() -> requestClose()`: closing a floating window or a main window (Alt+F4, taskbar, QWidget::close()) closes the contained dock widgets, honouring `DockWidgetOption_DeleteOnClose` and per-widget close vetoes, because the KDDW view is itself the top-level widget and receives closeEvent() directly.

However the QtQuick frontend had no equivalent for either window role:
- `QuickView` (the `QWindow` KDDW creates behind a floating window) did not handle `QEvent::Close` at all.
- The `MainWindow` view is an item inside an application-owned `QWindow` and never sees that window's close events.

In both cases a native window close merely hid the `QWindow`: dock widgets and their guest items stayed alive, `DeleteOnClose` never applied, and non-closable dock widgets could not veto.

This fixes both by:
1. `QuickView::event()` forwards `QEvent::Close` to the floating window's `requestClose()`, mirroring the `QtWidgets` frontend.
2. The `MainWindow` view installs an event filter on its host window (tracked in the constructor and via `itemChange()`; note the scene-add notification during the base `QQuickItem` constructor cannot reach the subclass override) and forwards `QEvent::Close` to `requestClose()`, which the core `MainWindow` already routes to `Layout::onCloseEvent()`.

Adds `tst_floatingWindowNativeClose` and `tst_mainWindowNativeClose`. Each fails without its respective fix (the `DeleteOnClose` dock widget survives the window close) and passes with it. I also verified against `examples/qtquick/pure_qml/delete_on_close.qml`. Tests for `DeleteOnClose` already existed (tst_deleteOnClose), but they close via `DockWidget::close()`, which synthesizes a `QCloseEvent` and delivers it directly to the item-level view through `requestClose()`. A native close is delivered to the `QWindow` instead, and nothing translated it to the view, so the existing tests couldn't catch this. The new tests close the actual `QWindow`.
