### PR TITLE
Fix MDI dockwidgets not honouring the initial size

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,6 @@
 * v2.5.0
+  - Fix MDI not honouring initial size property
+  - qtquick: Support setting floating window flags from QML
 
 * v2.4.1
   - qtquick: Fixed support for one window with multiple docking areas

--- a/src/core/MDILayout.cpp
+++ b/src/core/MDILayout.cpp
@@ -39,7 +39,7 @@ void MDILayout::addDockWidget(Core::DockWidget *dw, Point localPt,
         return;
     }
 
-    const Size dwSize = dw->size();
+    const Size dwSize = addingOption.preferredSize.isEmpty() ? dw->size() : addingOption.preferredSize;
 
     auto group = object_cast<Core::Group *>(dw->d->group());
     if (itemForGroup(group) != nullptr) {

--- a/src/qtquick/MainWindowMDIInstantiator.cpp
+++ b/src/qtquick/MainWindowMDIInstantiator.cpp
@@ -46,14 +46,15 @@ QVector<QString> MainWindowMDIInstantiator::affinities() const
 }
 
 void MainWindowMDIInstantiator::addDockWidget(QQuickItem *dockWidget, QPoint localPos,
-                                              const InitialOption &addingOption)
+                                              QSize initialSize,
+                                              InitialVisibilityOption visibilityOption)
 {
     if (!dockWidget || !m_mainWindow)
         return;
 
     Core::DockWidget *dw = QtQuick::Platform::dockWidgetForItem(dockWidget);
 
-    m_mainWindow->mdiLayout()->addDockWidget(dw, localPos, addingOption);
+    m_mainWindow->mdiLayout()->addDockWidget(dw, localPos, InitialOption(visibilityOption, initialSize));
 }
 
 bool MainWindowMDIInstantiator::closeDockWidgets(bool force)

--- a/src/qtquick/MainWindowMDIInstantiator.h
+++ b/src/qtquick/MainWindowMDIInstantiator.h
@@ -43,8 +43,8 @@ public:
 
     QVector<QString> affinities() const;
 
-    Q_INVOKABLE void addDockWidget(QQuickItem *dockWidget, QPoint localPos,
-                                   const KDDockWidgets::InitialOption &addingOption = {});
+    Q_INVOKABLE void addDockWidget(QQuickItem *dockWidget, QPoint localPos, QSize initialSize = {},
+                                   KDDockWidgets::InitialVisibilityOption = {});
 
     Q_INVOKABLE bool closeDockWidgets(bool force = false);
 

--- a/tests/main_mdiInitialSize.qml
+++ b/tests/main_mdiInitialSize.qml
@@ -1,0 +1,39 @@
+/*
+  This file is part of KDDockWidgets.
+
+  SPDX-FileCopyrightText: 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  Author: Sergio Martins <sergio.martins@kdab.com>
+
+  SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+
+  Contact KDAB at <info@kdab.com> for commercial licensing options.
+*/
+
+import QtQuick 2.6
+import QtQuick.Controls 2.12
+import com.kdab.dockwidgets 2.0 as KDDW
+
+ApplicationWindow {
+    visible: true
+    width: 1000
+    height: 800
+
+    KDDW.MDIDockingArea {
+        id: dockingArea
+        anchors.fill: parent
+        uniqueName: "mdiInitialSizeMainWindow"
+    }
+
+    KDDW.DockWidget {
+        id: dock1
+        uniqueName: "mdiInitialSizeDock"
+        Rectangle {
+            anchors.fill: parent
+            color: "#413C58"
+        }
+    }
+
+    Component.onCompleted: {
+        dockingArea.addDockWidget(dock1, Qt.point(20, 20), Qt.size(520, 800));
+    }
+}

--- a/tests/qtquick/tst_qtquick.cpp
+++ b/tests/qtquick/tst_qtquick.cpp
@@ -21,6 +21,7 @@
 #include "qtquick/views/MainWindow.h"
 #include "qtquick/views/FloatingWindow.h"
 #include "core/MDILayout.h"
+#include "core/layouting/Item_p.h"
 #include "core/views/MainWindowViewInterface.h"
 #include "core/MainWindow.h"
 #include "core/Window_p.h"
@@ -65,6 +66,7 @@ private Q_SLOTS:
     void tst_setPersistentCentralView();
 
     void tst_mdiFixedSize();
+    void tst_mdiInitialSizeFromQml();
     void tst_affinities();
 
     void tst_deleteDockWidget();
@@ -464,6 +466,29 @@ void TestQtQuick::tst_mdiFixedSize()
     // 1 event loop for DelayedDelete. Avoids LSAN warnings.
     Platform::instance()
         ->tests_wait(1);
+}
+
+void TestQtQuick::tst_mdiInitialSizeFromQml()
+{
+    // Tests that MDIDockingArea.addDockWidget() can be given an initial size from QML,
+    // without needing the workaround of setting dockWidget.width/height before adding it.
+
+    EnsureTopLevelsDeleted e;
+    QQmlApplicationEngine engine(":/main_mdiInitialSize.qml");
+
+    auto mainWindow = DockRegistry::self()->mainWindowByName("mdiInitialSizeMainWindow");
+    QVERIFY(mainWindow);
+
+    auto dock1 = DockRegistry::self()->dockByName("mdiInitialSizeDock");
+    QVERIFY(dock1);
+
+    Core::Group *group = dock1->dptr()->group();
+    QVERIFY(group);
+    QVERIFY(group->isMDI());
+
+    Core::Item *item = mainWindow->layout()->itemForGroup(group);
+    QVERIFY(item);
+    QCOMPARE(item->size(), Size(520, 800));
 }
 
 void TestQtQuick::tst_affinities()

--- a/tests/test_resources.qrc
+++ b/tests/test_resources.qrc
@@ -24,5 +24,6 @@
 	    <file>main_tst_focusBetweenTabs.qml</file>
         <file>MyRectangle2.qml</file>
         <file>main_titleBarHasMinimizeButton.qml</file>
+        <file>main_mdiInitialSize.qml</file>
 </qresource>
 </RCC>


### PR DESCRIPTION
You can now pass a size to area.addDockWidget()