### PR TITLE
qtquick: In MDI mode, fix random splitters getting highlighted

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -2,6 +2,7 @@
   - Fix MDI not honouring initial size property
   - qtquick: Support setting floating window flags from QML
   - qtquick: Support dark mode
+  - qtquick: In MDI, fix random splitters getting highlighted
 
 * v2.4.1
   - qtquick: Fixed support for one window with multiple docking areas

--- a/src/qtquick/views/qml/Group.qml
+++ b/src/qtquick/views/qml/Group.qml
@@ -56,6 +56,13 @@ Rectangle {
     MouseArea {
         anchors.fill: parent
 
+        // Claims hover for the whole Group, so Qt Quick's occlusion-aware
+        // hit-testing stops here instead of walking through to whatever is rendered behind
+        // this Group in MDI mode (e.g. a splitter belonging to an overlapping, unrelated
+        // dock widget)
+        hoverEnabled: true
+        cursorShape: Qt.ArrowCursor
+
         MDIResizeHandlerHelper {
             anchors {
                 left: parent ? parent.left : undefined


### PR DESCRIPTION
If you had dock A over dock B, and that dock B had a splitter, then if you hovered over A, splitter B would highlight, because A was transparent for hover events and would forward it.