### PR TITLE
ci: Don't build Qt5/QtQuick in CI to improve turnaround times

### DIFF
--- a/.github/workflows/build-qt5.yml
+++ b/.github/workflows/build-qt5.yml
@@ -61,16 +61,10 @@ jobs:
       - name: Build Project ${{ matrix.preset.build_preset_arg }}
         run: cmake --build ./build-${{ matrix.preset.name }} ${{ matrix.preset.build_preset_arg }}
 
-      - name: Run tests on Linux
-        if: ${{ startsWith(matrix.preset.name, 'ci-dev-') && runner.os == 'Linux' }}
+      - name: Run tests
         run: ctest --test-dir ./build-${{ matrix.preset.name }} --verbose -j 4
         env:
-          QT_QUICK_BACKEND: software
           LSAN_OPTIONS: detect_leaks=${{ matrix.preset.detect_leaks }}
-
-      - name: Run tests on Window/macOS
-        if: ${{ startsWith(matrix.preset.name, 'ci-dev-') && runner.os != 'Linux' }}
-        run: ctest --test-dir ./build-${{ matrix.preset.name }} --verbose -j 4
 
       - name: Read tests log when it fails
         uses: andstor/file-reader-action@v1

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -52,7 +52,8 @@
       "displayName": "dev",
       "binaryDir": "${sourceDir}/build-dev",
       "cacheVariables": {
-        "KDDockWidgets_QT6": "OFF"
+        "KDDockWidgets_QT6": "OFF",
+        "KDDockWidgets_FRONTENDS": "qtwidgets"
       },
       "inherits": [
         "dev-base"
@@ -64,7 +65,8 @@
       "description": "An ASAN/UBSAN build",
       "binaryDir": "${sourceDir}/build-dev-asan",
       "cacheVariables": {
-        "KDDockWidgets_QT6": "OFF"
+        "KDDockWidgets_QT6": "OFF",
+        "KDDockWidgets_FRONTENDS": "qtwidgets"
       },
       "inherits": [
         "dev-base",
@@ -161,7 +163,7 @@
         "CMAKE_BUILD_TYPE": "Release",
         "KDDockWidgets_QT6": "OFF",
         "CMAKE_UNITY_BUILD": "OFF",
-        "KDDockWidgets_FRONTENDS": "qtwidgets;qtquick"
+        "KDDockWidgets_FRONTENDS": "qtwidgets"
       }
     },
     {
@@ -174,7 +176,7 @@
         "KDDockWidgets_QT6": "OFF",
         "CMAKE_UNITY_BUILD": "OFF",
         "KDDockWidgets_X11EXTRAS": "OFF",
-        "KDDockWidgets_FRONTENDS": "qtwidgets;qtquick"
+        "KDDockWidgets_FRONTENDS": "qtwidgets"
       }
     },
     {
@@ -186,18 +188,6 @@
         "KDDockWidgets_PYTHON_BINDINGS": "ON",
         "CMAKE_UNITY_BUILD": "OFF",
         "KDDockWidgets_FRONTENDS": "qtwidgets;qtquick"
-      }
-    },
-    {
-      "name": "python",
-      "displayName": "Qt5 python bindings",
-      "generator": "Ninja",
-      "binaryDir": "${sourceDir}/build-python",
-      "inherits": [
-        "python-base"
-      ],
-      "cacheVariables": {
-        "KDDockWidgets_QT6": "OFF"
       }
     },
     {
@@ -441,7 +431,7 @@
         "KDDockWidgets_DEVELOPER_MODE": "ON",
         "KDDockWidgets_QT6": "OFF",
         "CMAKE_BUILD_TYPE": "Debug",
-        "KDDockWidgets_FRONTENDS": "qtwidgets;qtquick"
+        "KDDockWidgets_FRONTENDS": "qtwidgets"
       }
     },
     {
@@ -454,33 +444,7 @@
         "KDDockWidgets_DEVELOPER_MODE": "OFF",
         "KDDockWidgets_QT6": "OFF",
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-        "KDDockWidgets_FRONTENDS": "qtwidgets;qtquick"
-      }
-    },
-    {
-      "name": "ci-qtwidgets-qt5",
-      "displayName": "ci-qtwidgets-qt5",
-      "description": "Qt5 build which excludes QtQuick",
-      "binaryDir": "${sourceDir}/build-ci-qtwidgets-qt5",
-      "generator": "Ninja",
-      "cacheVariables": {
-        "KDDockWidgets_DEVELOPER_MODE": "OFF",
-        "KDDockWidgets_QT6": "OFF",
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "KDDockWidgets_FRONTENDS": "qtwidgets"
-      }
-    },
-    {
-      "name": "ci-qtquick-qt5",
-      "displayName": "ci-qtquick-qt5",
-      "description": "Qt5 build which excludes QtWidgets",
-      "binaryDir": "${sourceDir}/build-ci-qtquick-qt5",
-      "generator": "Ninja",
-      "cacheVariables": {
-        "KDDockWidgets_DEVELOPER_MODE": "OFF",
-        "KDDockWidgets_QT6": "OFF",
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-        "KDDockWidgets_FRONTENDS": "qtquick"
       }
     },
     {


### PR DESCRIPTION
We've already stated in README that KDDW-QtQuick requires Qt 6. It still works and we'll add important fixes for legacy users.

But it needs to phase out as it's very difficult to maintain two sets of .qml files, since we can't ifdef to support 2 Qt versions.